### PR TITLE
Adding type constraints to PrivateDataService to resolve build failure

### DIFF
--- a/pdslib/src/pds/implem.rs
+++ b/pdslib/src/pds/implem.rs
@@ -7,37 +7,37 @@ use crate::queries::traits::ReportRequest;
 /// storage and event storage interfaces. We might want other implementations
 /// eventually, but at first this implementation should cover most use cases,
 /// as we can swap the types of events, filters and queries.
-pub struct PrivateDataServiceImpl<Filters: FilterStorage, Events: EventStorage>
+pub struct PrivateDataServiceImpl<Filters: FilterStorage, Events: EventStorage, RR: ReportRequest>
 {
     pub filter_storage: Filters,
     pub event_storage: Events,
+    pub report_request: RR
 }
 
-impl<FS, ES, E, EI, EE> PrivateDataService for PrivateDataServiceImpl<FS, ES>
+impl<FS, ES, E, RR, EI, EE> PrivateDataService for PrivateDataServiceImpl<FS, ES, RR>
 where
     // Q: Query, // TODO: maybe particular type?
     FS: FilterStorage,
     ES: EventStorage<Event = E, EpochEvents = EE>,
     E: Event<EpochId = EI>,
+    RR: ReportRequest<EpochId = EI, EpochEvents = EE>
 {
     type Event = E;
-    type EpochId = EI;
-    type EpochEvents = EE;
-    // type ReportRequest = ReportRequest;
-    // type Report = Report;
+    type ReportRequest = RR;
+    type Report = RR::Report;
 
     fn register_event(&mut self, event: E) -> Result<(), ()> {
         println!("Registering event {:?}", event);
         self.event_storage.add_event(event)
     }
 
-    fn compute_report<R: ReportRequest<EpochId = EI, EpochEvents = EE>>(&mut self, request: R) -> R::Report
+    fn compute_report(&mut self, request: Self:: ReportRequest) -> Self::Report
     {
         print!("Computing report for request {:?}", request);
         // TODO: collect events from event storage.
         // It means the request should give a list of epochs.
 
-        let mut all_epoch_events: Vec<EE> = vec![];
+        let mut all_epoch_events: Vec<_> = vec![];
         for epoch_id in request.get_epoch_ids() {
             // TODO: ensure epochs match.
             let epoch_events = self.event_storage.get_epoch_events(epoch_id);

--- a/pdslib/src/pds/traits.rs
+++ b/pdslib/src/pds/traits.rs
@@ -2,13 +2,11 @@ use crate::queries::traits::ReportRequest;
 
 pub trait PrivateDataService {
     type Event;
-    type EpochId;
-    type EpochEvents;
-    // type ReportRequest;
-    // type Report; // TODO: is this going to be a union type over possible reports? Sounds pretty resonable. Or trait with dynamic dispatch?
+    type ReportRequest;
+    type Report; // TODO: is this going to be a union type over possible reports? Sounds pretty resonable. Or trait with dynamic dispatch?
 
     fn register_event(&mut self, event: Self::Event) -> Result<(), ()>;
 
     // TODO: where do we restrict the list of supported query types? Maybe allow them all to run for now, an return null reports if not supported?
-    fn compute_report<R: ReportRequest<EpochId = Self::EpochId, EpochEvents = Self::EpochEvents>>(&mut self, request: R) -> R::Report;
+    fn compute_report(&mut self, request: Self:: ReportRequest) -> Self::Report;
 }


### PR DESCRIPTION
Both EpochId and EpochEvents type constraints are added to PrivateDataService.