### PR TITLE
Implemented functionality to filter for relevant events

### DIFF
--- a/pdslib/src/events/simple_events.rs
+++ b/pdslib/src/events/simple_events.rs
@@ -52,6 +52,8 @@ impl EventStorage for SimpleEventStorage {
     type EpochEvents = SimpleEpochEvents; // TODO: use a pointer and add lifetime? Or just copy for now, nice to edit
                                           // inplace anyway.
 
+    type RelevantEventSelector = fn(&Self::Event) -> bool;
+
     fn add_event(
         &mut self,
         event: Self::Event,
@@ -63,17 +65,18 @@ impl EventStorage for SimpleEventStorage {
         Ok(())
     }
 
-    fn get_epoch_events<F>(
+    fn get_epoch_events(
         &self,
         epoch_id: &<Self::Event as Event>::EpochId,
-        is_relevant_event: F,
-    ) -> Option<Self::EpochEvents> 
-    where
-        F: Fn(&Self::Event) -> bool,
-    {
+        is_relevant_event: &Self::RelevantEventSelector,
+    ) -> Option<Self::EpochEvents> {
         // Return relevant events for a given epoch_id
-        self.epochs.get(&epoch_id).map(|events|{
-            events.iter().filter(|event| is_relevant_event(event)).cloned().collect()
+        self.epochs.get(&epoch_id).map(|events| {
+            events
+                .iter()
+                .filter(|event| is_relevant_event(event))
+                .cloned()
+                .collect()
         })
     }
 }

--- a/pdslib/src/events/traits.rs
+++ b/pdslib/src/events/traits.rs
@@ -21,17 +21,16 @@ pub trait EpochEvents: Debug {
 pub trait EventStorage {
     type Event: Event;
     type EpochEvents: EpochEvents;
+    type RelevantEventSelector;
 
     /// Stores a new event.
     fn add_event(&mut self, event: Self::Event) -> Result<(), ()>;
 
     /// Retrieves all events for a given epoch.
     /// TODO: allow to filter relevant events for a query?
-    fn get_epoch_events<F>(
+    fn get_epoch_events(
         &self,
         epoch_id: &<Self::Event as Event>::EpochId,
-        is_relevant_event: F,
-    ) -> Option<Self::EpochEvents>
-    where 
-        F: Fn(&Self::Event) -> bool;
+        relevant_event_selector: &Self::RelevantEventSelector,
+    ) -> Option<Self::EpochEvents>;
 }

--- a/pdslib/src/pds/implem.rs
+++ b/pdslib/src/pds/implem.rs
@@ -28,15 +28,15 @@ pub struct PrivateDataServiceImpl<
     pub _phantom: std::marker::PhantomData<Q>,
 }
 
-impl<EI, E, EE, FS, ES, Q> PrivateDataService
+impl<EI, E, EE, RES, FS, ES, Q> PrivateDataService
     for PrivateDataServiceImpl<FS, ES, Q>
 where
     EI: EpochId,
     E: Event<EpochId = EI>,
     EE: EpochEvents,
     FS: FilterStorage<FilterId = EI, Budget = PureDPBudget>, /* NOTE: we'll want to support other budgets eventually */
-    ES: EventStorage<Event = E, EpochEvents = EE>,
-    Q: EpochQuery<EpochId = EI, EpochEvents = EE>,
+    ES: EventStorage<Event = E, EpochEvents = EE, RelevantEventSelector = RES>,
+    Q: EpochQuery<EpochId = EI, EpochEvents = EE, RelevantEventSelector = RES>,
 {
     type Event = E;
     type Query = Q;
@@ -46,17 +46,16 @@ where
         self.event_storage.add_event(event)
     }
 
-    fn compute_report<F>(&mut self, request: Q, is_relevant_event: F) -> <Q as Query>::Report 
-    where 
-        F: Fn(&Self::Event) -> bool,
-    {
+    fn compute_report(&mut self, request: Q) -> <Q as Query>::Report {
         println!("Computing report for request {:?}", request);
         // Collect events from event storage. If an epoch has no relevant
         // events, don't add it to the mapping.
         let mut map_of_events_set_over_epochs: HashMap<EI, EE> = HashMap::new();
+        let relevant_event_selector = request.get_relevant_event_selector();
         for epoch_id in request.get_epoch_ids() {
-            if let Some(epoch_events) =
-                self.event_storage.get_epoch_events(&epoch_id, &is_relevant_event)
+            if let Some(epoch_events) = self
+                .event_storage
+                .get_epoch_events(&epoch_id, &relevant_event_selector)
             {
                 map_of_events_set_over_epochs.insert(epoch_id, epoch_events);
             }

--- a/pdslib/src/pds/traits.rs
+++ b/pdslib/src/pds/traits.rs
@@ -12,11 +12,8 @@ pub trait PrivateDataService {
     fn register_event(&mut self, event: Self::Event) -> Result<(), ()>;
 
     /// Computes a report for the given query.
-    fn compute_report<F>(
+    fn compute_report(
         &mut self,
         query: Self::Query,
-        is_relevant_event: F,
-    ) -> <Self::Query as Query>::Report
-    where 
-    F: Fn(&Self::Event) -> bool;
+    ) -> <Self::Query as Query>::Report;
 }

--- a/pdslib/src/queries/traits.rs
+++ b/pdslib/src/queries/traits.rs
@@ -22,11 +22,16 @@ pub trait Query: Debug {
 pub trait EpochQuery: Query {
     type EpochId: EpochId;
     type EpochEvents: EpochEvents;
+    type RelevantEventSelector;
     type PrivacyBudget;
     type ReportGlobalSensitivity;
 
     /// Returns the list of epoch IDs, in the order the attribution should run.
     fn get_epoch_ids(&self) -> Vec<Self::EpochId>;
+
+    /// Returns the selector for relevant events for the query. The selector
+    /// can be passed to the event storage to retrieve only the relevant events.
+    fn get_relevant_event_selector(&self) -> Self::RelevantEventSelector;
 
     /// Computes the report for the given request and epoch events.
     fn compute_report(

--- a/pdslib/tests/demo.rs
+++ b/pdslib/tests/demo.rs
@@ -45,8 +45,9 @@ fn main() {
         epoch_end: 1,
         attributable_value: 3.0,
         noise_scale: 1.0,
+        is_relevant_event: always_relevant_event,
     };
-    let report = pds.compute_report(report_request, always_relevant_event);
+    let report = pds.compute_report(report_request);
     let bucket = Some((event.epoch_number, event.event_key, 3.0));
     assert_eq!(report.attributed_value, bucket);
 
@@ -61,8 +62,9 @@ fn main() {
                        * limit as the current budget left for
                        * epoch 1 is 0. */
         noise_scale: 1.0,
+        is_relevant_event: always_relevant_event,
     };
-    let report2 = pds.compute_report(report_request2, always_relevant_event);
+    let report2 = pds.compute_report(report_request2);
     // Allocated budget for epoch 1 is 3.0, but 3.0 has already been consumed in
     // the last request, so the budget is depleted. Now, the null report should
     // be returned for this additional query.
@@ -73,8 +75,9 @@ fn main() {
         epoch_end: 2,
         attributable_value: 3.0,
         noise_scale: 1.0,
+        is_relevant_event: always_relevant_event,
     };
-    let report2 = pds.compute_report(report_request2, always_relevant_event);
+    let report2 = pds.compute_report(report_request2);
     let bucket2 = Some((event2.epoch_number, event2.event_key, 3.0));
     assert_eq!(report2.attributed_value, bucket2);
 
@@ -85,8 +88,9 @@ fn main() {
         epoch_end: 3,   // Epoch 3 not created yet.
         attributable_value: 0.0,
         noise_scale: 1.0,
+        is_relevant_event: always_relevant_event,
     };
-    let report3_empty = pds.compute_report(report_request3_empty, always_relevant_event);
+    let report3_empty = pds.compute_report(report_request3_empty);
     assert_eq!(report3_empty.attributed_value, None);
 
     // Test restricting attributable_value
@@ -97,8 +101,9 @@ fn main() {
         epoch_end: 3,
         attributable_value: 4.0,
         noise_scale: 1.0,
+        is_relevant_event: always_relevant_event,
     };
-    let report3_over_budget = pds.compute_report(report_request3_over_budget, always_relevant_event);
+    let report3_over_budget = pds.compute_report(report_request3_over_budget);
     assert_eq!(report3_over_budget.attributed_value, None);
 
     // This tests the case where we meet the first event in epoch 3, below the
@@ -108,12 +113,25 @@ fn main() {
         epoch_end: 3,
         attributable_value: 3.0,
         noise_scale: 1.0,
+        is_relevant_event: always_relevant_event,
     };
-    let report3 = pds.compute_report(report_request3, always_relevant_event);
+    let report3 = pds.compute_report(report_request3);
     let bucket3 = Some((event4.epoch_number, event3.event_key, 3.0));
     assert_eq!(report3.attributed_value, bucket3);
+
+    // Check that irrelevant events are ignored
+    let report_request4 = SimpleLastTouchHistogramRequest {
+        epoch_start: 1,
+        epoch_end: 3,
+        attributable_value: 3.0,
+        noise_scale: 1.0,
+        is_relevant_event: |e: &SimpleEvent| e.event_key == 1,
+    };
+    let report4 = pds.compute_report(report_request4);
+    let bucket4: Option<(usize, usize, f64)> = None;
+    assert_eq!(report4.attributed_value, bucket4);
 }
 
-fn always_relevant_event(event : &SimpleEvent) -> bool{
+fn always_relevant_event(_: &SimpleEvent) -> bool {
     true
 }


### PR DESCRIPTION
This PR adds functionality to filter for relevant events. To achieve this, the following is changed
- **implem.rs**: a `is_relevant_event: Fn(&Self::Event) -> bool` parameter to the `compute_report` function
- **simple_events.rs**: a `is_relevant_event` parameter to the `get_epoch_events`. `is_relevant_event` is used to filter for and return only relevant events when events are collected for a given epoch_id from the EventStorage
- **tests/demo.rs**: accommodating the above changes