### PR TITLE
Do not specify patch version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ name = "pdslib"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-thiserror = "2.0.3"
-anyhow = "1.0.93"
+thiserror = "2.0"
+anyhow = "1.0"
 log = "0.4"
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 log4rs = "1"


### PR DESCRIPTION
Only specify major/minor versions of dependencies, not patch. So we specify `anyhow = 1.0` instead of `1.0.219`.

[Full documentation of how Cargo.toml semver works](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)

In short:
- `anyhow = 1.0` allows any version ≥1.0.0 and <2.0.0
- `anyhow = 1.0.219` allows any version ≥1.0.219 and <2.0.0

This change is very useful on the Firefox integration side, as all Rust dependencies in Firefox need to be vendored in-tree i.e. downloaded and checked into version control. This means that adding or upgrading a dependency (even indirect ones) requires re-vendoring, which is hard (all deps need to be vetted) and causes a huge git diff.   For example, Firefox currently uses anyhow 1.0.69. Pdslib requires anyhow 1.0.93, so compiling Firefox with pdslib causes it to complain since it can't use 1.0.93 without vendoring it (and you can't vendor a single crate! So all rust crates need to be re-vendored and vetted etc.)

Instead, relaxing the pdslib dependency solves this immediately, and makes it more flexible when included in other projects in the future.