### PR TITLE
Replace (almost) all uses of `usize` with `u64`

### DIFF
--- a/src/events/ppa_event.rs
+++ b/src/events/ppa_event.rs
@@ -8,14 +8,14 @@ use crate::events::traits::{Event, EventUris};
 pub struct PpaEvent<U: Uri = String> {
     /// Event ID, e.g., counter or random ID. Unused in Firefox but kept for
     /// debugging purposes.
-    pub id: usize,
+    pub id: u64,
 
     /// Timestamp, also for debugging purposes.
     pub timestamp: u64,
 
-    pub epoch_number: usize,
+    pub epoch_number: u64,
 
-    pub histogram_index: usize,
+    pub histogram_index: u64,
 
     pub uris: EventUris<U>,
 
@@ -28,7 +28,7 @@ pub struct PpaEvent<U: Uri = String> {
 }
 
 impl<U: Uri> Event for PpaEvent<U> {
-    type EpochId = usize;
+    type EpochId = u64;
     type Uri = U;
 
     fn epoch_id(&self) -> Self::EpochId {

--- a/src/events/simple_event.rs
+++ b/src/events/simple_event.rs
@@ -7,14 +7,14 @@ use crate::events::traits::{Event, EventUris};
 /// richer type.
 #[derive(Debug, Clone)]
 pub struct SimpleEvent<U: Uri = String> {
-    pub id: usize,
-    pub epoch_number: usize,
-    pub event_key: usize,
+    pub id: u64,
+    pub epoch_number: u64,
+    pub event_key: u64,
     pub uris: EventUris<U>,
 }
 
 impl<U: Uri> Event for SimpleEvent<U> {
-    type EpochId = usize;
+    type EpochId = u64;
     type Uri = U;
 
     fn epoch_id(&self) -> Self::EpochId {

--- a/src/pds/aliases.rs
+++ b/src/pds/aliases.rs
@@ -22,7 +22,7 @@ use crate::{
 
 pub type SimpleFilterStorage = HashMapFilterStorage<
     PureDPBudgetFilter,
-    StaticCapacities<FilterId<usize, String>, PureDPBudget>,
+    StaticCapacities<FilterId<u64, String>, PureDPBudget>,
 >;
 pub type SimpleEventStorage = HashMapEventStorage<SimpleEvent>;
 pub type SimplePdsCore<FS = SimpleFilterStorage> =
@@ -34,7 +34,7 @@ pub type SimplePds<FS = SimpleFilterStorage, ES = SimpleEventStorage> =
 
 pub type PpaFilterStorage = HashMapFilterStorage<
     PureDPBudgetFilter,
-    StaticCapacities<FilterId<usize, String>, PureDPBudget>,
+    StaticCapacities<FilterId<u64, String>, PureDPBudget>,
 >;
 pub type PpaEventStorage = HashMapEventStorage<PpaEvent>;
 pub type PpaPdsCore<FS = PpaFilterStorage, ERR = anyhow::Error> =

--- a/src/pds/quotas.rs
+++ b/src/pds/quotas.rs
@@ -6,7 +6,7 @@ use crate::budget::traits::{Budget, FilterCapacities};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum FilterId<
-    E = usize,  // Epoch ID
+    E = u64,    // Epoch ID
     U = String, // URI
 > {
     /// Non-collusion per-querier filter

--- a/src/queries/histogram.rs
+++ b/src/queries/histogram.rs
@@ -18,7 +18,7 @@ pub struct HistogramReport<BucketKey> {
 pub trait BucketKey: Debug + Hash + Eq + Clone {}
 
 /// Default type for bucket keys.
-impl BucketKey for usize {}
+impl BucketKey for u64 {}
 
 /// Default histogram has no bins (null report).
 impl<BK> Default for HistogramReport<BK> {
@@ -74,7 +74,7 @@ where
     /// Gets the querier bucket mapping for filtering histograms
     fn get_bucket_intermediary_mapping(
         &self,
-    ) -> Option<&HashMap<usize, Self::HistogramUri>>;
+    ) -> Option<&HashMap<u64, Self::HistogramUri>>;
 
     /// Filter a histogram for a specific querier
     fn filter_report_for_intermediary(

--- a/src/queries/ppa_histogram.rs
+++ b/src/queries/ppa_histogram.rs
@@ -19,13 +19,13 @@ use crate::{
     },
 };
 
-type PpaBucketKey = usize;
-type PpaEpochId = usize;
+type PpaBucketKey = u64;
+type PpaEpochId = u64;
 
 pub struct PpaRelevantEventSelector<U: Uri = String> {
     pub report_request_uris: ReportRequestUris<U>,
     pub is_matching_event: Box<dyn Fn(u64) -> bool>,
-    pub bucket_intermediary_mapping: HashMap<usize, U>,
+    pub bucket_intermediary_mapping: HashMap<u64, U>,
 }
 
 impl<U: Uri> std::fmt::Debug for PpaRelevantEventSelector<U> {
@@ -40,8 +40,8 @@ impl<U: Uri> std::fmt::Debug for PpaRelevantEventSelector<U> {
 /// global sensitivity) instead of directly Laplace noise scale.
 #[derive(Debug, Clone)]
 pub struct PpaHistogramConfig {
-    pub start_epoch: usize,
-    pub end_epoch: usize,
+    pub start_epoch: u64,
+    pub end_epoch: u64,
 
     /// Conversion value that is spread across events for this conversion.
     pub attributable_value: f64,
@@ -51,7 +51,7 @@ pub struct PpaHistogramConfig {
 
     /// Budget spent on the batch, considering the max_attributable_value.
     pub requested_epsilon: f64,
-    pub histogram_size: usize,
+    pub histogram_size: u64,
 }
 
 /// Alternative configuration that directly provides Laplace noise scale.
@@ -59,12 +59,12 @@ pub struct PpaHistogramConfig {
 /// configuration.
 #[derive(Debug, Clone)]
 pub struct DirectPpaHistogramConfig {
-    pub start_epoch: usize,
-    pub end_epoch: usize,
+    pub start_epoch: u64,
+    pub end_epoch: u64,
     /// Conversion value that is spread across events
     pub attributable_value: f64,
     pub laplace_noise_scale: f64,
-    pub histogram_size: usize,
+    pub histogram_size: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -109,12 +109,12 @@ impl<U: Uri> RelevantEventSelector for PpaRelevantEventSelector<U> {
 
 #[derive(Debug)]
 pub struct PpaHistogramRequest<U: Uri = String> {
-    start_epoch: usize,
-    end_epoch: usize,
+    start_epoch: u64,
+    end_epoch: u64,
     /// Conversion value that is spread across events
     attributable_value: f64,
     laplace_noise_scale: f64,
-    histogram_size: usize,
+    histogram_size: u64,
     relevant_event_selector: PpaRelevantEventSelector<U>,
     logic: AttributionLogic,
 }
@@ -182,14 +182,14 @@ impl<U: Uri> PpaHistogramRequest<U> {
         })
     }
 
-    pub fn get_bucket_intermediary_mapping(&self) -> &HashMap<usize, U> {
+    pub fn get_bucket_intermediary_mapping(&self) -> &HashMap<u64, U> {
         &self.relevant_event_selector.bucket_intermediary_mapping
     }
 
     // Helper to check if a bucket is for a specific intermediary
     pub fn is_bucket_for_intermediary(
         &self,
-        bucket_key: usize,
+        bucket_key: u64,
         intermediary_uri: &U,
     ) -> bool {
         match self
@@ -266,7 +266,7 @@ impl<U: Uri> HistogramRequest for PpaHistogramRequest<U> {
         vec![]
     }
 
-    fn get_bucket_intermediary_mapping(&self) -> Option<&HashMap<usize, U>> {
+    fn get_bucket_intermediary_mapping(&self) -> Option<&HashMap<u64, U>> {
         Some(&self.relevant_event_selector.bucket_intermediary_mapping)
     }
 
@@ -276,8 +276,8 @@ impl<U: Uri> HistogramRequest for PpaHistogramRequest<U> {
         intermediary_uri: &U,
         _relevant_events_per_epoch: &RelevantEvents<Self::HistogramEvent>,
     ) -> Option<HistogramReport<Self::BucketKey>> {
-        // Collect all usize keys whose value matches intermediary_uri
-        let intermediary_buckets: HashSet<usize> = self
+        // Collect all u64 keys whose value matches intermediary_uri
+        let intermediary_buckets: HashSet<u64> = self
             .relevant_event_selector
             .bucket_intermediary_mapping
             .iter()

--- a/src/queries/simple_last_touch_histogram.rs
+++ b/src/queries/simple_last_touch_histogram.rs
@@ -14,8 +14,8 @@ use crate::{
 
 #[derive(Debug)]
 pub struct SimpleLastTouchHistogramRequest {
-    pub epoch_start: usize,
-    pub epoch_end: usize,
+    pub epoch_start: u64,
+    pub epoch_end: u64,
     pub report_global_sensitivity: f64,
     pub query_global_sensitivity: f64,
     pub requested_epsilon: f64,
@@ -47,15 +47,15 @@ impl std::fmt::Debug for SimpleRelevantEventSelector {
 pub struct SimpleLastTouchHistogramReport {
     // Value attributed to one bin or None if no attribution
     pub bin_value: Option<(
-        usize, // Bucket key (which is just event_key for now)
-        f64,   // Attributed value
+        u64, // Bucket key (which is just event_key for now)
+        f64, // Attributed value
     )>,
 }
 
 impl Report for SimpleLastTouchHistogramReport {}
 
 impl EpochReportRequest for SimpleLastTouchHistogramRequest {
-    type EpochId = usize;
+    type EpochId = u64;
     type Event = SimpleEvent;
     type PrivacyBudget = PureDPBudget;
     type RelevantEventSelector = SimpleRelevantEventSelector;

--- a/src/queries/traits.rs
+++ b/src/queries/traits.rs
@@ -9,14 +9,14 @@ use crate::{
 };
 
 pub struct QueryComputeResult<U, R> {
-    pub bucket_uri_map: HashMap<usize, U>,
+    pub bucket_uri_map: HashMap<u64, U>,
     pub uri_report_map: HashMap<U, R>,
 }
 
 impl<U, R> QueryComputeResult<U, R> {
     // Example methods, if you need them
     pub fn new(
-        bucket_uri_map: HashMap<usize, U>,
+        bucket_uri_map: HashMap<u64, U>,
         uri_report_map: HashMap<U, R>,
     ) -> Self {
         Self {

--- a/tests/simple_events_demo.rs
+++ b/tests/simple_events_demo.rs
@@ -215,7 +215,7 @@ fn main() -> Result<(), anyhow::Error> {
         report_uris: sample_report_uris.clone(),
     };
     let report4 = pds.compute_report(&report_request4)?;
-    let bucket4: Option<(usize, f64)> = None;
+    let bucket4: Option<(u64, f64)> = None;
     assert_eq!(
         report4
             .get(&report_request4.report_uris.querier_uris[0])


### PR DESCRIPTION
Fixes: #12

This is basically just a `grep` of the codebase to replace `usize` with `u64`.

The `num_epoch` argument to `compute_epoch_loss()` and `compute_epoch_source_losses()` are the only places with `usize` left:
https://github.com/columbia/pdslib/blob/c5c7fd721a63a55b67e0e65555ef4ad527c5035a/src/pds/accounting.rs#L16-L21
Since the argument represents the `.len()` of a vec, and it's not used by FFI at all, I think it's OK to leave as-is. 