### PR TITLE
Rename filters to match the paper's terminology

### DIFF
--- a/src/budget/hashmap_filter_storage.rs
+++ b/src/budget/hashmap_filter_storage.rs
@@ -93,7 +93,7 @@ mod tests {
         let mut storage: HashMapFilterStorage<PureDPBudgetFilter, _> =
             HashMapFilterStorage::new(capacities)?;
 
-        let fid: FilterId<i32, ()> = FilterId::C(1);
+        let fid: FilterId<i32, ()> = FilterId::Global(1);
         assert_eq!(storage.try_consume(&fid, &10.0)?, FilterStatus::Continue);
         assert_eq!(
             storage.try_consume(&fid, &11.0)?,

--- a/src/pds/batch_pds.rs
+++ b/src/pds/batch_pds.rs
@@ -80,7 +80,7 @@ where
     ERR: From<FS::Error> + From<ES::Error>,
 {
     /// Current scheduling interval.
-    /// Used to release budget for the c-filter.
+    /// Used to release budget for the Global filter.
     pub current_scheduling_interval: u64,
 
     /// Queries that arrived during the current interval.
@@ -102,7 +102,7 @@ where
     /// List of all the different sources that appear in each epoch.
     pub sources_per_epoch: HashMap<Q::EpochId, HashSet<Q::Uri>>,
 
-    /// Amount of c-filter budget to be released per scheduling interval.
+    /// Amount of Global filter budget to be released per scheduling interval.
     pub eps_c_per_release: FS::Budget,
 
     /// NOTE: these filters are not actually directly visible to a querier,
@@ -148,10 +148,12 @@ where
     ) -> Result<Self, ERR> {
         let capacities = pds.core.filter_storage.capacities().clone();
 
-        // Release the c-filter over T scheduling intervals.
-        let eps_c_per_release = match capacities.c {
+        // Release the Global filter over T scheduling intervals.
+        let eps_c_per_release = match capacities.global {
             f64::INFINITY => {
-                debug!("C-filter has infinite capacity. Release is a no-op");
+                debug!(
+                    "Global filter has infinite capacity. Release is a no-op"
+                );
                 0.0
             }
             eps_c => eps_c / (n_releases as f64),
@@ -247,7 +249,8 @@ where
         &mut self,
         batched_requests: Vec<BatchedRequest<Q>>,
     ) -> Result<Vec<BatchedRequest<Q>>, ERR> {
-        let imp_capacity = self.pds.core.filter_storage.capacities().qsource;
+        let imp_capacity =
+            self.pds.core.filter_storage.capacities().source_quota;
 
         // Just try all the past epochs since our experiments just have a
         // few. Could eventually discard epochs that have reached their
@@ -337,17 +340,21 @@ where
 
         let mut filter_ids = vec![];
         for epoch_id in request.epoch_ids() {
-            // Build the filter IDs for NC, C and QTrigger. Qsource has the same
-            // loss here.
+            // Build the filter IDs for PerQuerier, Global and TriggerQuota.
+            // SourceQuota has the same loss here.
             for query_uri in &uris.querier_uris {
-                filter_ids.push(FilterId::Nc(epoch_id, query_uri.clone()));
+                filter_ids
+                    .push(FilterId::PerQuerier(epoch_id, query_uri.clone()));
             }
-            filter_ids
-                .push(FilterId::QTrigger(epoch_id, uris.trigger_uri.clone()));
-            filter_ids.push(FilterId::C(epoch_id));
+            filter_ids.push(FilterId::TriggerQuota(
+                epoch_id,
+                uris.trigger_uri.clone(),
+            ));
+            filter_ids.push(FilterId::Global(epoch_id));
 
             for source in &uris.source_uris {
-                filter_ids.push(FilterId::QSource(epoch_id, source.clone()));
+                filter_ids
+                    .push(FilterId::SourceQuota(epoch_id, source.clone()));
             }
         }
 
@@ -452,9 +459,10 @@ where
 
                 if !report.oob_filters.is_empty() {
                     for filter_id in report.oob_filters.iter() {
-                        if let FilterId::QSource(_, _) = filter_id {
-                            // Qimp should never block a request if we have
-                            // perfect upper bounds for the public filters.
+                        if let FilterId::SourceQuota(_, _) = filter_id {
+                            // SourceQuota should never block a request if we
+                            // have perfect upper
+                            // bounds for the public filters.
                             panic!(
                                 "Request {} was not allocated: {:?}. Final attempt? {}",
                                 request.request_id, report.oob_filters, allocate_final_attempts
@@ -515,7 +523,7 @@ where
         if let Some(sources) = self.sources_per_epoch.get(&epoch) {
             let filter_ids = sources
                 .iter()
-                .map(|source| FilterId::QSource(epoch, source.clone()))
+                .map(|source| FilterId::SourceQuota(epoch, source.clone()))
                 .collect::<Vec<_>>();
             self.initialize_filters(filter_ids.iter())?;
 
@@ -538,7 +546,7 @@ where
     /// Release budget for the given epoch. This is a no-op when the epoch's
     /// unlocked budget has reached the capacity.
     fn release_budget(&mut self, epoch: Q::EpochId) -> Result<(), ERR> {
-        let filter_id = FilterId::C(epoch);
+        let filter_id = FilterId::Global(epoch);
 
         self.pds
             .core
@@ -581,7 +589,7 @@ where
             let source = (*source).clone();
             let mut source_total_budget: f64 = 0.0;
             for epoch in &all_epochs {
-                let filter_id = FilterId::QSource(*epoch, source.clone());
+                let filter_id = FilterId::SourceQuota(*epoch, source.clone());
 
                 let filter =
                     self.public_filters.get_filter_or_new(&filter_id)?;
@@ -658,8 +666,8 @@ where
     }
 
     /// Given a request, calculate the list of filters that will be deducted
-    /// from by PDS core, and pre-initialize them, so that all non-C filters
-    /// are unlocked and act as regular filters.
+    /// from by PDS core, and pre-initialize them, so that all non-global
+    /// filters are unlocked and act as regular filters.
     fn initialize_filters_for_request(
         &mut self,
         request: &Q,
@@ -686,7 +694,7 @@ where
     }
 
     /// Given a list of filter IDs, initialize them in the filter storage,
-    /// such that non-C filters are unlocked and act as regular filters.
+    /// such that non-global filters are unlocked and act as regular filters.
     fn initialize_filters<'f, FID>(
         &mut self,
         filters: impl Iterator<Item = FID>,
@@ -700,12 +708,12 @@ where
         for filter_id in filters {
             let filter_id = filter_id.borrow();
 
-            // Only C-filters should act as release filters. Nc, q-conv and
-            // q-imp act as regular PureDPBudget filters.
+            // Only Global filters should act as release filters. PerQuerier,
+            // Trigger and Source act as regular PureDPBudget filters.
             // As FilterStorage only supports storing one type of filter,
             // we fully unlock all other filter types before consuming.
             // As such, they act as regular non-release filters.
-            let should_unlock = !matches!(filter_id, FilterId::C(_));
+            let should_unlock = !matches!(filter_id, FilterId::Global(_));
 
             // if we don't need to unlock, we don't need to do anything
             if !should_unlock {
@@ -828,8 +836,8 @@ mod tests {
         ))?;
 
         // Another request with one scheduling attempt. But it doesn't go
-        // through the online phase because of qimp, instead it has to wait
-        // until the batch phase for the quotas to be disabled.
+        // through the online phase because of SourceQuota, instead it has to
+        // wait until the batch phase for the quotas to be disabled.
         request_config.requested_epsilon = 1.2;
         batch_pds.register_report_request(BatchedRequest::new(
             2,
@@ -997,8 +1005,8 @@ mod tests {
 
         let unallocated_new_requests = batch_pds.online_phase(new_requests)?;
 
-        // Because of qimp, news.ex can't accept all the queries. Also tried to
-        // allocate in order.
+        // Because of SourceQuota, news.ex can't accept all the queries. Also
+        // tried to allocate in order.
         assert_eq!(
             collect_request_ids(&unallocated_new_requests),
             vec![6, 7, 8, 9]

--- a/src/pds/core.rs
+++ b/src/pds/core.rs
@@ -192,25 +192,27 @@ where
         source_losses: &'a HashMap<Q::Uri, FS::Budget>,
         uris: &ReportRequestUris<Q::Uri>,
     ) -> HashMap<FilterId<Q::EpochId, Q::Uri>, &'a PureDPBudget> {
-        // Build the filter IDs for NC, C and QTrigger
+        // Build the filter IDs for PerQuerier, Global and TriggerQuota
         let mut device_epoch_filter_ids = Vec::new();
         for query_uri in &uris.querier_uris {
             device_epoch_filter_ids
-                .push(FilterId::Nc(epoch_id, query_uri.clone()));
+                .push(FilterId::PerQuerier(epoch_id, query_uri.clone()));
         }
         device_epoch_filter_ids
-            .push(FilterId::QTrigger(epoch_id, uris.trigger_uri.clone()));
-        device_epoch_filter_ids.push(FilterId::C(epoch_id));
+            .push(FilterId::TriggerQuota(epoch_id, uris.trigger_uri.clone()));
+        device_epoch_filter_ids.push(FilterId::Global(epoch_id));
 
-        // NC, C and QTrigger all have the same device-epoch level loss
+        // PerQuerier, Global and TriggerQuota all have the same device-epoch
+        // level loss
         let mut filters_to_consume = HashMap::new();
         for filter_id in device_epoch_filter_ids {
             filters_to_consume.insert(filter_id, loss);
         }
 
-        // Add the QSource filters with their own device-epoch-source level loss
+        // Add the SourceQuota filters with their own device-epoch-source level
+        // loss
         for (source, loss) in source_losses {
-            let fid = FilterId::QSource(epoch_id, source.clone());
+            let fid = FilterId::SourceQuota(epoch_id, source.clone());
             filters_to_consume.insert(fid, loss);
         }
 

--- a/src/pds/quotas.rs
+++ b/src/pds/quotas.rs
@@ -15,32 +15,32 @@ pub enum FilterId<
     U = String, // URI
 > {
     /// Non-collusion per-querier filter
-    Nc(E, U /* querier URI */),
+    PerQuerier(E, U /* querier URI */),
 
     /// Collusion filter (tracks overall privacy loss)
-    C(E),
+    Global(E),
 
-    /// Quota filter regulating c-filter consumption per trigger_uri
-    QTrigger(E, U /* trigger URI */),
+    /// Quota filter regulating Global filter consumption per trigger_uri
+    TriggerQuota(E, U /* trigger URI */),
 
-    /// Quota filter regulating c-filter consumption per source_uri
-    QSource(E, U /* source URI */),
+    /// Quota filter regulating Global filter consumption per source_uri
+    SourceQuota(E, U /* source URI */),
 }
 
 impl<E: Display, U: Display> fmt::Display for FilterId<E, U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FilterId::Nc(epoch_id, querier_uri) => {
-                write!(f, "Nc({epoch_id}, {querier_uri})")
+            FilterId::PerQuerier(epoch_id, querier_uri) => {
+                write!(f, "PerQuerier({epoch_id}, {querier_uri})")
             }
-            FilterId::C(epoch_id) => {
-                write!(f, "C({epoch_id})")
+            FilterId::Global(epoch_id) => {
+                write!(f, "Global({epoch_id})")
             }
-            FilterId::QTrigger(epoch_id, trigger_uri) => {
-                write!(f, "QTrigger({epoch_id}, {trigger_uri})")
+            FilterId::TriggerQuota(epoch_id, trigger_uri) => {
+                write!(f, "TriggerQuota({epoch_id}, {trigger_uri})")
             }
-            FilterId::QSource(epoch_id, source_uri) => {
-                write!(f, "QSource({epoch_id}, {source_uri})")
+            FilterId::SourceQuota(epoch_id, source_uri) => {
+                write!(f, "SourceQuota({epoch_id}, {source_uri})")
             }
         }
     }
@@ -49,22 +49,27 @@ impl<E: Display, U: Display> fmt::Display for FilterId<E, U> {
 /// Struct containing the default capacity for each type of filter.
 #[derive(Debug, Clone, Serialize)]
 pub struct StaticCapacities<FID, B> {
-    pub nc: B,
-    pub c: B,
-    pub qtrigger: B,
-    pub qsource: B,
+    pub per_querier: B,
+    pub global: B,
+    pub trigger_quota: B,
+    pub source_quota: B,
 
     #[serde(skip_serializing)]
     _phantom: std::marker::PhantomData<FID>,
 }
 
 impl<FID, B> StaticCapacities<FID, B> {
-    pub fn new(nc: B, c: B, qtrigger: B, qsource: B) -> Self {
+    pub fn new(
+        per_querier: B,
+        global: B,
+        trigger_quota: B,
+        source_quota: B,
+    ) -> Self {
         Self {
-            nc,
-            c,
-            qtrigger,
-            qsource,
+            per_querier,
+            global,
+            trigger_quota,
+            source_quota,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -80,10 +85,10 @@ impl<B: Budget, E, U> FilterCapacities for StaticCapacities<FilterId<E, U>, B> {
         filter_id: &Self::FilterId,
     ) -> Result<Self::Budget, Self::Error> {
         match filter_id {
-            FilterId::Nc(..) => Ok(self.nc.clone()),
-            FilterId::C(..) => Ok(self.c.clone()),
-            FilterId::QTrigger(..) => Ok(self.qtrigger.clone()),
-            FilterId::QSource(..) => Ok(self.qsource.clone()),
+            FilterId::PerQuerier(..) => Ok(self.per_querier.clone()),
+            FilterId::Global(..) => Ok(self.global.clone()),
+            FilterId::TriggerQuota(..) => Ok(self.trigger_quota.clone()),
+            FilterId::SourceQuota(..) => Ok(self.source_quota.clone()),
         }
     }
 }

--- a/src/pds/tests.rs
+++ b/src/pds/tests.rs
@@ -53,9 +53,15 @@ fn test_account_for_passive_privacy_loss() -> Result<(), anyhow::Error> {
     for epoch_id in 1..=3 {
         // we consumed 0.5 so far
         let expected_budgets = vec![
-            (FilterId::Nc(epoch_id, uris.querier_uris[0].clone()), 0.5),
-            (FilterId::C(epoch_id), 19.5),
-            (FilterId::QTrigger(epoch_id, uris.trigger_uri.clone()), 1.0),
+            (
+                FilterId::PerQuerier(epoch_id, uris.querier_uris[0].clone()),
+                0.5,
+            ),
+            (FilterId::Global(epoch_id), 19.5),
+            (
+                FilterId::TriggerQuota(epoch_id, uris.trigger_uri.clone()),
+                1.0,
+            ),
         ];
 
         assert_remaining_budgets(
@@ -74,7 +80,7 @@ fn test_account_for_passive_privacy_loss() -> Result<(), anyhow::Error> {
     assert!(matches!(result, PdsFilterStatus::OutOfBudget(_)));
     if let PdsFilterStatus::OutOfBudget(oob_filters) = result {
         assert!(oob_filters
-            .contains(&FilterId::Nc(2, uris.querier_uris[0].clone())));
+            .contains(&FilterId::PerQuerier(2, uris.querier_uris[0].clone())));
     }
 
     // Consume from just one epoch.
@@ -89,9 +95,9 @@ fn test_account_for_passive_privacy_loss() -> Result<(), anyhow::Error> {
     // Verify remaining budgets
     for epoch_id in 1..=2 {
         let expected_budgets = vec![
-            (Nc(epoch_id, uris.querier_uris[0].clone()), 0.5),
-            (C(epoch_id), 19.5),
-            (QTrigger(epoch_id, uris.trigger_uri.clone()), 1.0),
+            (PerQuerier(epoch_id, uris.querier_uris[0].clone()), 0.5),
+            (Global(epoch_id), 19.5),
+            (TriggerQuota(epoch_id, uris.trigger_uri.clone()), 1.0),
         ];
 
         assert_remaining_budgets(
@@ -100,11 +106,11 @@ fn test_account_for_passive_privacy_loss() -> Result<(), anyhow::Error> {
         )?;
     }
 
-    // epoch 3's nc-filter and q-conv should be out of budget
+    // epoch 3's PerQuerier and TriggerQuota should be out of budget
     let remaining = pds
         .core
         .filter_storage
-        .remaining_budget(&Nc(3, uris.querier_uris[0].clone()))?;
+        .remaining_budget(&PerQuerier(3, uris.querier_uris[0].clone()))?;
     assert_eq!(remaining, PureDPBudget::from(0.0));
 
     Ok(())
@@ -134,10 +140,10 @@ fn test_budget_rollback_on_depletion() -> Result<(), anyhow::Error> {
     // PDS with several filters
     let capacities: StaticCapacities<FilterId, PureDPBudget> =
         StaticCapacities::new(
-            PureDPBudget::from(1.0),  // nc
-            PureDPBudget::from(20.0), // c
-            PureDPBudget::from(2.0),  // q-trigger
-            PureDPBudget::from(5.0),  // q-source
+            PureDPBudget::from(1.0),  // PerQuerier
+            PureDPBudget::from(20.0), // Global
+            PureDPBudget::from(2.0),  // TriggerQuota
+            PureDPBudget::from(5.0),  // SourceQuota
         );
 
     let filters = SimpleFilterStorage::new(capacities)?;
@@ -154,11 +160,11 @@ fn test_budget_rollback_on_depletion() -> Result<(), anyhow::Error> {
     // Initialize all filters for epoch 1
     let epoch_id = 1;
     let filter_ids = vec![
-        FilterId::C(epoch_id),
-        FilterId::Nc(epoch_id, uris.querier_uris[0].clone()),
-        FilterId::Nc(epoch_id, uris.querier_uris[1].clone()),
-        FilterId::QTrigger(epoch_id, uris.trigger_uri.clone()),
-        FilterId::QSource(epoch_id, uris.source_uris[0].clone()),
+        FilterId::Global(epoch_id),
+        FilterId::PerQuerier(epoch_id, uris.querier_uris[0].clone()),
+        FilterId::PerQuerier(epoch_id, uris.querier_uris[1].clone()),
+        FilterId::TriggerQuota(epoch_id, uris.trigger_uri.clone()),
+        FilterId::SourceQuota(epoch_id, uris.source_uris[0].clone()),
     ];
 
     // Record initial budgets
@@ -171,14 +177,14 @@ fn test_budget_rollback_on_depletion() -> Result<(), anyhow::Error> {
     }
 
     // Set up a request that will succeed for most filters but fail for one
-    // Make the NC filter for querier1 have only 0.5 epsilon left
+    // Make the PerQuerier filter for querier1 have only 0.5 epsilon left
     pds.core.filter_storage.try_consume(
-        &FilterId::Nc(epoch_id, uris.querier_uris[0].clone()),
+        &FilterId::PerQuerier(epoch_id, uris.querier_uris[0].clone()),
         &PureDPBudget::from(0.5),
     )?;
 
     // Now attempt a deduction that requires 0.7 epsilon
-    // This should fail because querier1's NC filter only has 0.5 left
+    // This should fail because querier1's PerQuerier filter only has 0.5 left
     let request = PassivePrivacyLossRequest {
         epoch_ids: vec![epoch_id],
         privacy_budget: PureDPBudget::from(0.7),
@@ -188,25 +194,29 @@ fn test_budget_rollback_on_depletion() -> Result<(), anyhow::Error> {
     let result = pds.account_for_passive_privacy_loss(request)?;
     assert!(matches!(result, PdsFilterStatus::OutOfBudget(_)));
     if let PdsFilterStatus::OutOfBudget(oob_filters) = result {
-        assert!(oob_filters
-            .contains(&FilterId::Nc(1, "querier1.example.com".to_string())));
+        assert!(oob_filters.contains(&FilterId::PerQuerier(
+            1,
+            "querier1.example.com".to_string()
+        )));
     }
 
     // Check that all other filters were not modified
-    // First verify that querier1's NC filter still has 0.5 epsilon
+    // First verify that querier1's PerQuerier filter still has 0.5 epsilon
     assert_eq!(
-        pds.core.filter_storage.remaining_budget(&FilterId::Nc(
-            epoch_id,
-            uris.querier_uris[0].clone()
-        ))?,
+        pds.core
+            .filter_storage
+            .remaining_budget(&FilterId::PerQuerier(
+                epoch_id,
+                uris.querier_uris[0].clone()
+            ))?,
         PureDPBudget::from(0.5),
         "Filter that was insufficient should still have its partial budget"
     );
 
     // Then verify the other filters still have their original budgets
     for filter_id in &filter_ids {
-        // Skip the querier1 NC filter we already checked
-        if matches!(filter_id, FilterId::Nc(_, uri) if uri == &uris.querier_uris[0])
+        // Skip the querier1 PerQuerier filter we already checked
+        if matches!(filter_id, FilterId::PerQuerier(_, uri) if uri == &uris.querier_uris[0])
         {
             continue;
         }
@@ -318,8 +328,9 @@ fn test_cross_report_optimization() -> Result<(), anyhow::Error> {
         },
     )
     .map_err(|e| anyhow::anyhow!("Failed to create request: {}", e))?;
-    // Initialize and check the initial beneficiary's NC filter
-    let beneficiary_filter_id = FilterId::Nc(1, beneficiary_uri.clone());
+    // Initialize and check the initial beneficiary's PerQuerier filter
+    let beneficiary_filter_id =
+        FilterId::PerQuerier(1, beneficiary_uri.clone());
     let initial_budget = pds
         .core
         .filter_storage


### PR DESCRIPTION
Renamed the following:
Nc => PerQuerier
C => Global
QTrigger / q-conv => TriggerQuota
QSource / q-imp => SourceQuota

Note: I didn't rename beneficiary => querier as both seem to be used in the paper