### PR TITLE
Add feature to use ahash for faster hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy 0.8.26",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +137,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -303,6 +329,7 @@ dependencies = [
 name = "pdslib"
 version = "0.3.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "log",
  "log4rs",
@@ -316,7 +343,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -336,6 +363,12 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -364,7 +397,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -564,10 +597,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -729,13 +777,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive 0.8.26",
 ]
 
 [[package]]
@@ -743,6 +809,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
- "zerocopy 0.8.26",
+ "zerocopy",
 ]
 
 [[package]]
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arc-swap"
@@ -45,48 +45,42 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -131,13 +125,13 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -154,26 +148,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -189,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -199,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -215,15 +210,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -231,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "serde",
 ]
@@ -274,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "num-traits"
@@ -289,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ordered-float"
@@ -304,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -314,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -339,27 +334,27 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -397,29 +392,29 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -454,14 +449,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -490,9 +485,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -507,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -542,7 +537,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -553,7 +548,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -577,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unsafe-any-ors"
@@ -604,9 +599,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -639,7 +634,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -661,7 +656,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -699,18 +694,62 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-targets"
@@ -787,32 +826,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.8.26",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -823,5 +841,5 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.103",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,15 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 default = []
-experimental = [] # Experimental algorithms and APIs
+experimental = []     # Experimental algorithms and APIs
+ahash = ["dep:ahash"] # Use ahash for HashMap and HashSet
 
 [dependencies]
 thiserror = "2.0"
 anyhow = "1.0"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
+ahash = { version = "0.8.12", features = ["serde"], optional = true }
 
 [dev-dependencies]
 log4rs = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "2.0"
 anyhow = "1.0"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-ahash = { version = "0.8.12", features = ["serde"], optional = true }
+ahash = { version = "0.8", features = ["serde"], optional = true }
 
 [dev-dependencies]
 log4rs = "1.2"

--- a/src/budget/hashmap_filter_storage.rs
+++ b/src/budget/hashmap_filter_storage.rs
@@ -1,8 +1,11 @@
-use std::{collections::HashMap, fmt::Debug, hash::Hash};
+use std::{fmt::Debug, hash::Hash};
 
 use serde::{ser::SerializeStruct, Serialize};
 
-use crate::budget::traits::{Filter, FilterCapacities, FilterStorage};
+use crate::{
+    budget::traits::{Filter, FilterCapacities, FilterStorage},
+    util::hashmap::HashMap,
+};
 
 /// Simple implementation of FilterStorage using a HashMap.
 /// Works for any Filter that implements the Filter trait.
@@ -20,7 +23,7 @@ impl<F, C, FID> Serialize for HashMapFilterStorage<F, C>
 where
     C: FilterCapacities<FilterId = FID> + Serialize,
     F: Filter<C::Budget> + Serialize,
-    FID: Serialize,
+    FID: Serialize + Eq + Hash + Debug,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/budget/traits.rs
+++ b/src/budget/traits.rs
@@ -49,7 +49,7 @@ pub enum FilterStatus {
 }
 
 pub trait FilterCapacities {
-    type FilterId;
+    type FilterId: Eq;
     type Budget: Budget;
     type Error;
 

--- a/src/events/hashmap_event_storage.rs
+++ b/src/events/hashmap_event_storage.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
-
-use crate::events::traits::{Event, EventStorage};
+use crate::{
+    events::traits::{Event, EventStorage},
+    util::hashmap::HashMap,
+};
 
 /// A simple in-memory event storage. Stores a mapping of epoch id to epoch
 /// events, where each epoch events is just a vec of events.

--- a/src/events/relevant_events.rs
+++ b/src/events/relevant_events.rs
@@ -1,6 +1,5 @@
-use std::collections::{HashMap, HashSet};
-
 use super::traits::{Event, EventStorage, RelevantEventSelector};
+use crate::util::hashmap::{HashMap, HashSet};
 
 /// A struct that holds relevant events for a set of epochs.
 ///

--- a/src/pds/accounting.rs
+++ b/src/pds/accounting.rs
@@ -1,5 +1,4 @@
 use core::f64;
-use std::collections::{HashMap, HashSet};
 
 use log::debug;
 
@@ -7,6 +6,7 @@ use crate::{
     budget::pure_dp_filter::PureDPBudget,
     mechanisms::{NoiseScale, NormType},
     queries::traits::EpochReportRequest,
+    util::hashmap::{HashMap, HashSet},
 };
 
 /// Pure DP individual privacy loss, following

--- a/src/pds/aliases.rs
+++ b/src/pds/aliases.rs
@@ -32,9 +32,9 @@ pub type SimplePds<FS = SimpleFilterStorage, ES = SimpleEventStorage> =
 
 // === PPA aliases ===
 
-pub type PpaFilterStorage = HashMapFilterStorage<
+pub type PpaFilterStorage<U = String> = HashMapFilterStorage<
     PureDPBudgetFilter,
-    StaticCapacities<FilterId<u64, String>, PureDPBudget>,
+    StaticCapacities<FilterId<u64, U>, PureDPBudget>,
 >;
 pub type PpaEventStorage<U = String> = HashMapEventStorage<PpaEvent<U>>;
 pub type PpaPdsCore<FS = PpaFilterStorage, U = String, ERR = anyhow::Error> =

--- a/src/pds/batch_pds.rs
+++ b/src/pds/batch_pds.rs
@@ -4,7 +4,6 @@ use core::panic;
 use std::{
     borrow::Borrow,
     cmp::Ordering::{Greater, Less},
-    collections::{HashMap, HashSet},
     fmt::Debug,
     mem::take,
     vec,
@@ -26,6 +25,7 @@ use crate::{
     mechanisms::NoiseScale,
     pds::quotas::FilterId,
     queries::traits::EpochReportRequest,
+    util::hashmap::{HashMap, HashSet},
 };
 
 #[derive(Debug)]

--- a/src/pds/core.rs
+++ b/src/pds/core.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, collections::HashMap, marker::PhantomData, vec};
+use std::{cell::Cell, marker::PhantomData, vec};
 
 use log::debug;
 
@@ -14,6 +14,7 @@ use crate::{
     },
     events::relevant_events::RelevantEvents,
     queries::traits::{EpochReportRequest, Report, ReportRequestUris},
+    util::hashmap::HashMap,
 };
 
 pub struct PrivateDataServiceCore<Q, FS, ERR>

--- a/src/pds/cross_report.rs
+++ b/src/pds/cross_report.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    vec,
-};
+use std::vec;
 
 use log::{debug, warn};
 
@@ -28,6 +25,7 @@ use crate::{
         },
         traits::EpochReportRequest,
     },
+    util::hashmap::{HashMap, HashSet},
 };
 
 /// The attribution object that can be used to compute distinct
@@ -274,8 +272,6 @@ impl<U: Uri> AttributionObject<PpaHistogramRequest<U>> {
 
 #[cfg(test)]
 mod tests {
-
-    use std::collections::HashMap;
 
     use super::*;
     use crate::{

--- a/src/pds/private_data_service.rs
+++ b/src/pds/private_data_service.rs
@@ -1,5 +1,4 @@
 #[cfg(feature = "experimental")]
-use std::collections::HashMap;
 use std::fmt::Debug;
 
 use log::debug;
@@ -13,6 +12,7 @@ use crate::{
 #[cfg(feature = "experimental")]
 use crate::{
     pds::quotas::PdsFilterStatus, queries::traits::PassivePrivacyLossRequest,
+    util::hashmap::HashMap,
 };
 
 /// Epoch-based private data service, using generic filter

--- a/src/pds/quotas.rs
+++ b/src/pds/quotas.rs
@@ -7,13 +7,13 @@ use std::{
 
 use serde::Serialize;
 
-use crate::budget::traits::{Budget, FilterCapacities};
+use crate::{
+    budget::traits::{Budget, FilterCapacities},
+    events::traits::{EpochId, Uri},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-pub enum FilterId<
-    E = u64,    // Epoch ID
-    U = String, // URI
-> {
+pub enum FilterId<E: EpochId = u64, U: Uri = String> {
     /// Non-collusion per-querier filter
     PerQuerier(E, U /* querier URI */),
 
@@ -27,7 +27,7 @@ pub enum FilterId<
     SourceQuota(E, U /* source URI */),
 }
 
-impl<E: Display, U: Display> fmt::Display for FilterId<E, U> {
+impl<E: EpochId + Display, U: Uri + Display> fmt::Display for FilterId<E, U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FilterId::PerQuerier(epoch_id, querier_uri) => {
@@ -75,7 +75,9 @@ impl<FID, B> StaticCapacities<FID, B> {
     }
 }
 
-impl<B: Budget, E, U> FilterCapacities for StaticCapacities<FilterId<E, U>, B> {
+impl<B: Budget, E: EpochId, U: Uri> FilterCapacities
+    for StaticCapacities<FilterId<E, U>, B>
+{
     type FilterId = FilterId<E, U>;
     type Budget = B;
     type Error = anyhow::Error;

--- a/src/pds/tests.rs
+++ b/src/pds/tests.rs
@@ -1,7 +1,4 @@
 #[cfg(feature = "experimental")]
-use std::collections::HashMap;
-
-#[cfg(feature = "experimental")]
 use crate::{
     budget::{pure_dp_filter::PureDPBudget, traits::FilterStorage},
     pds::quotas::{FilterId, PdsFilterStatus, StaticCapacities},
@@ -11,6 +8,7 @@ use crate::{
     },
     queries::traits::PassivePrivacyLossRequest,
     queries::traits::ReportRequestUris,
+    util::hashmap::HashMap,
 };
 
 #[test]

--- a/src/queries/histogram.rs
+++ b/src/queries/histogram.rs
@@ -1,9 +1,10 @@
-use std::{collections::HashMap, fmt::Debug, hash::Hash};
+use std::{fmt::Debug, hash::Hash};
 
 use crate::{
     events::relevant_events::RelevantEvents,
     mechanisms::NormType,
     queries::traits::{EpochReportRequest, Report, ReportRequestUris},
+    util::hashmap::HashMap,
 };
 
 #[derive(Debug, Clone)]

--- a/src/queries/ppa_histogram.rs
+++ b/src/queries/ppa_histogram.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    vec,
-};
+use std::vec;
 
 use anyhow::{bail, Result};
 
@@ -17,6 +14,7 @@ use crate::{
         histogram::{BucketKey, HistogramReport, HistogramRequest},
         traits::{EpochReportRequest, ReportRequestUris},
     },
+    util::hashmap::{HashMap, HashSet},
 };
 
 pub type PpaBucketKey = u64;

--- a/src/util/hashmap.rs
+++ b/src/util/hashmap.rs
@@ -1,0 +1,5 @@
+#[cfg(not(feature = "ahash"))]
+pub use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "ahash")]
+pub use ahash::{AHashMap as HashMap, AHashSet as HashSet};

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,2 @@
+pub mod hashmap;
 pub mod tests;

--- a/tests/common/logging.rs
+++ b/tests/common/logging.rs
@@ -1,5 +1,6 @@
 use log4rs;
 
+#[allow(unused)] // used in tests
 pub fn init_default_logging() {
     log4rs::init_file("log4rs.yaml", Default::default()).unwrap();
 }

--- a/tests/ppa_bench.rs
+++ b/tests/ppa_bench.rs
@@ -21,7 +21,7 @@ use pdslib::{
 };
 
 #[test]
-// #[ignore]
+#[ignore]
 fn bench_compute_report() -> anyhow::Result<()> {
     logging::init_default_logging();
 

--- a/tests/ppa_bench.rs
+++ b/tests/ppa_bench.rs
@@ -21,7 +21,7 @@ use pdslib::{
 };
 
 #[test]
-#[ignore]
+// #[ignore]
 fn bench_compute_report() -> anyhow::Result<()> {
     logging::init_default_logging();
 

--- a/tests/ppa_bench.rs
+++ b/tests/ppa_bench.rs
@@ -1,0 +1,72 @@
+mod common;
+
+use common::logging;
+use pdslib::{
+    budget::traits::FilterStorage as _,
+    events::{
+        ppa_event::PpaEvent,
+        traits::{EventStorage as _, EventUris},
+    },
+    pds::{
+        aliases::{PpaEventStorage, PpaFilterStorage, PpaPds},
+        quotas::StaticCapacities,
+    },
+    queries::{
+        ppa_histogram::{
+            PpaHistogramConfig, PpaHistogramRequest, PpaRelevantEventSelector,
+            RequestedBuckets,
+        },
+        traits::ReportRequestUris,
+    },
+};
+
+#[test]
+#[ignore]
+fn bench_compute_report() -> anyhow::Result<()> {
+    logging::init_default_logging();
+
+    let capacities = StaticCapacities::mock();
+    let filters = PpaFilterStorage::new(capacities)?;
+    let events = PpaEventStorage::new();
+    let mut pds = PpaPds::<_>::new(filters, events);
+
+    let event_uris = EventUris::mock();
+    let report_uris = ReportRequestUris::mock();
+
+    for i in 5..10000 {
+        // add 3 events
+        for j in 0..3 {
+            let event = PpaEvent {
+                id: j,
+                timestamp: 1000 + i * 100 + j,
+                epoch_number: i,
+                histogram_index: j,
+                uris: event_uris.clone(),
+                filter_data: 0,
+            };
+            pds.event_storage.add_event(event)?;
+        }
+
+        // compute the report for those 3 events
+        let request_config = PpaHistogramConfig {
+            start_epoch: i - 5,
+            end_epoch: i + 1,
+            attributable_value: 1.0,
+            max_attributable_value: 2.0,
+            requested_epsilon: 1.0,
+            histogram_size: 10,
+        };
+        let selector = PpaRelevantEventSelector {
+            report_request_uris: report_uris.clone(),
+            is_matching_event: Box::new(|_| true),
+            requested_buckets: RequestedBuckets::AllBuckets,
+        };
+        let request = PpaHistogramRequest::new(&request_config, selector)?;
+
+        let report = pds.compute_report(&request)?;
+
+        assert!(!report.filtered_report.bin_values.is_empty())
+    }
+
+    Ok(())
+}

--- a/tests/ppa_bench.rs
+++ b/tests/ppa_bench.rs
@@ -1,6 +1,5 @@
 mod common;
 
-use common::logging;
 use pdslib::{
     budget::traits::FilterStorage as _,
     events::{

--- a/tests/ppa_bench.rs
+++ b/tests/ppa_bench.rs
@@ -35,7 +35,7 @@ fn bench_compute_report() -> anyhow::Result<()> {
 
     for i in 5..10000 {
         // add 3 events
-        for j in 0..3 {
+        for j in 0..1000 {
             let event = PpaEvent {
                 id: j,
                 timestamp: 1000 + i * 100 + j,


### PR DESCRIPTION
In eval, a large majority of the runtime is spent in the hash function, reading/writing to/from HashMaps.

In rust's standard library, the HashMap hashing algorithm is [DoS resistant, with the downside that it's slower](https://nnethercote.github.io/perf-book/hashing.html#:~:text=The%20default%20hashing%20algorithm%20is,short%20keys%20such%20as%20integers.). [ahash](https://crates.io/crates/ahash) is a drop-in replacement that uses a faster hashing algorithm.

This PR adds an `ahash` optional feature which switches all HashMaps/Sets in pdslib to use ahash insead. It is optional as it requires users to also use `ahash` when passing HashMaps as arguments (instead of std's HashMap), for example in `EventStorage::from_mapping()`.

This also adds a benchmarking test. On my machine, using `ahash` speeds up the benchmarking function by 8.81s -> 8.27s, which makes sense as 99% of that benchmark is unfortunately spent logging to stdout. The eval code is noticeably faster though.