### PR TITLE
Add python bindings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,3 +28,26 @@ jobs:
         cargo test --package pdslib --features experimental --test simple_events_demo -- --nocapture
     - name: Run clippy
       run: cargo clippy --tests -- -D warnings
+
+  python:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        cd bindings/python
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install -e ".[dev]"
+    - name: Build and test
+      run: |
+        cd bindings/python
+        source .venv/bin/activate
+        pip install maturin
+        maturin develop
+        pytest tests/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
 name = "pdslib-python"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "pdslib",
  "pyo3",
 ]
@@ -399,6 +400,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
+ "anyhow",
  "indoc",
  "libc",
  "memoffset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,11 +395,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -413,19 +412,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -433,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -445,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -618,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +195,15 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -273,6 +288,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mock_instant"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +362,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdslib-python"
+version = "0.3.0"
+dependencies = [
+ "pdslib",
+ "pyo3",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +391,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -516,6 +617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +678,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-any-ors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "bindings/python"]
+
 [package]
 name = "pdslib"
 version = "0.3.0"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pdslib-python"
+version = "0.3.0"
+edition = "2024"
+
+[lib]
+name = "pdslib"
+crate-type = ["cdylib"]
+
+[dependencies]
+pdslib = { path = "../.." }
+pyo3 = { version = "0.23", features = ["extension-module"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -8,5 +8,6 @@ name = "pdslib_python"
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = "1"
 pdslib = { path = "../.." }
-pyo3 = { version = "0.27", features = ["extension-module"] }
+pyo3 = { version = "0.27", features = ["extension-module", "anyhow"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pdslib = { path = "../.." }
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.27", features = ["extension-module"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2024"
 
 [lib]
-name = "pdslib"
+name = "pdslib_python"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,42 @@
+# pdslib Python Bindings
+
+Python bindings for [pdslib](../../README.md) - on-device differential privacy budgeting for privacy-preserving attribution measurement APIs.
+
+## Setup
+
+```bash
+cd bindings/python
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+maturin develop
+```
+
+## Usage
+
+```python
+import pdslib
+
+print(pdslib.__version__)
+```
+
+## Development
+
+All commands below assume you're in `bindings/python/` with the venv activated:
+
+```bash
+cd bindings/python
+source .venv/bin/activate
+```
+
+### Run tests
+
+```bash
+pytest tests/
+```
+
+### Rebuild after Rust changes
+
+```bash
+maturin develop
+```

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,6 +1,7 @@
 # pdslib Python Bindings
 
-Python bindings for [pdslib](../../README.md) - on-device differential privacy budgeting for privacy-preserving attribution measurement APIs.
+Python bindings for [pdslib](../../README.md) - on-device differential privacy budgeting for privacy-preserving
+attribution measurement APIs.
 
 ## Setup
 
@@ -17,8 +18,64 @@ maturin develop
 ```python
 import pdslib_python
 
-print(pdslib_python.__version__)
+# Create a PDS instance with budget parameters
+pds = pdslib_python.Pds(
+    per_querier_budget=1.0,
+    global_budget=20.0,
+    trigger_quota=1.5,
+    source_quota=4.0,
+)
+
+# Register an event
+trigger_uris = pdslib_python.UriSet(["shoes.com"])
+querier_uris = pdslib_python.UriSet(["adtech.com"])
+event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
+
+event = pdslib_python.PpaEvent(
+    id=1,
+    timestamp=0,
+    epoch_number=1,
+    histogram_index=0x559,
+    uris=event_uris,
+    filter_data=1,  # event type identifier (e.g., 1=purchase, 2=add_to_cart)
+)
+pds.register_event(event)
+
+# Create a report request
+source_uris = pdslib_python.UriSet(["blog.com"])
+report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
+
+config = pdslib_python.PpaHistogramConfig(
+    start_epoch=1,
+    end_epoch=2,
+    attributable_value=32768.0,
+    max_attributable_value=65536.0,
+    requested_epsilon=1.0,
+    histogram_size=2048,
+)
+
+selector = pdslib_python.PpaRelevantEventSelector(
+    report_request_uris=report_uris,
+    filter_data=None,  # None matches all events (or use int to filter by type)
+    requested_buckets=pdslib_python.RequestedBuckets.all_buckets(),
+)
+
+request = pdslib_python.PpaHistogramRequest.new(config, selector)
+
+# Compute the report
+report = pds.compute_report(request)
+
+# Access results
+for bucket, value in report.bin_values:
+    print(f"Bucket {bucket}: {value}")
 ```
+
+## Notes
+
+- `PpaRelevantEventSelector.filter_data` is simplified from the Rust API. The Python bindings take
+  `int | None`, where `int` matches events with that exact `filter_data` value, and `None` matches all events.
+- Experimental features from the Rust library (`unfiltered_bin_values`, `oob_filters`) are not currently exposed in
+  these bindings.
 
 ## Development
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -15,9 +15,9 @@ maturin develop
 ## Usage
 
 ```python
-import pdslib
+import pdslib_python
 
-print(pdslib.__version__)
+print(pdslib_python.__version__)
 ```
 
 ## Development

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -35,6 +35,12 @@ source .venv/bin/activate
 pytest tests/
 ```
 
+Or from the repo root:
+
+```bash
+just python-test
+```
+
 ### Rebuild after Rust changes
 
 ```bash

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "pdslib"
+name = "pdslib_python"
 version = "0.3.0"
 description = "Python bindings for pdslib - on-device differential privacy budgeting"
 requires-python = ">=3.8"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "pdslib"
+version = "0.3.0"
+description = "Python bindings for pdslib - on-device differential privacy budgeting"
+requires-python = ">=3.8"
+
+[project.optional-dependencies]
+dev = ["pytest>=9.0"]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]

--- a/bindings/python/src/event_uris.rs
+++ b/bindings/python/src/event_uris.rs
@@ -5,6 +5,7 @@ use pdslib::events::traits::EventUris;
 use crate::uri_set::PyUriSet;
 
 #[pyclass(name = "EventUris", unsendable)]
+#[derive(Clone)]
 pub struct PyEventUris {
     pub inner: EventUris<String>,
 }

--- a/bindings/python/src/event_uris.rs
+++ b/bindings/python/src/event_uris.rs
@@ -1,0 +1,28 @@
+use pyo3::prelude::*;
+
+use pdslib::events::traits::EventUris;
+
+use crate::uri_set::PyUriSet;
+
+#[pyclass(name = "EventUris", unsendable)]
+pub struct PyEventUris {
+    pub inner: EventUris<String>,
+}
+
+#[pymethods]
+impl PyEventUris {
+    #[new]
+    fn new(
+        source_uri: String,
+        trigger_uris: PyUriSet,
+        querier_uris: PyUriSet,
+    ) -> Self {
+        PyEventUris {
+            inner: EventUris {
+                source_uri,
+                trigger_uris: trigger_uris.inner,
+                querier_uris: querier_uris.inner,
+            },
+        }
+    }
+}

--- a/bindings/python/src/filter_id.rs
+++ b/bindings/python/src/filter_id.rs
@@ -8,29 +8,6 @@ pub struct PyFilterId {
     pub inner: FilterId<u64, String>,
 }
 
-#[pymethods]
-impl PyFilterId {
-    #[getter]
-    fn filter_type(&self) -> &'static str {
-        match &self.inner {
-            FilterId::PerQuerier(_, _) => "PerQuerier",
-            FilterId::Global(_) => "Global",
-            FilterId::TriggerQuota(_, _) => "TriggerQuota",
-            FilterId::SourceQuota(_, _) => "SourceQuota",
-        }
-    }
-
-    #[getter]
-    fn epoch_id(&self) -> u64 {
-        *self.inner.epoch_id()
-    }
-
-    #[getter]
-    fn uri(&self) -> Option<String> {
-        self.inner.uri().cloned()
-    }
-}
-
 impl From<FilterId<u64, String>> for PyFilterId {
     fn from(inner: FilterId<u64, String>) -> Self {
         PyFilterId { inner }

--- a/bindings/python/src/filter_id.rs
+++ b/bindings/python/src/filter_id.rs
@@ -7,9 +7,3 @@ use pdslib::pds::quotas::FilterId;
 pub struct PyFilterId {
     pub inner: FilterId<u64, String>,
 }
-
-impl From<FilterId<u64, String>> for PyFilterId {
-    fn from(inner: FilterId<u64, String>) -> Self {
-        PyFilterId { inner }
-    }
-}

--- a/bindings/python/src/filter_id.rs
+++ b/bindings/python/src/filter_id.rs
@@ -1,9 +1,0 @@
-use pyo3::prelude::*;
-
-use pdslib::pds::quotas::FilterId;
-
-#[pyclass(name = "FilterId", unsendable)]
-#[derive(Clone)]
-pub struct PyFilterId {
-    pub inner: FilterId<u64, String>,
-}

--- a/bindings/python/src/filter_id.rs
+++ b/bindings/python/src/filter_id.rs
@@ -1,0 +1,38 @@
+use pyo3::prelude::*;
+
+use pdslib::pds::quotas::FilterId;
+
+#[pyclass(name = "FilterId", unsendable)]
+#[derive(Clone)]
+pub struct PyFilterId {
+    pub inner: FilterId<u64, String>,
+}
+
+#[pymethods]
+impl PyFilterId {
+    #[getter]
+    fn filter_type(&self) -> &'static str {
+        match &self.inner {
+            FilterId::PerQuerier(_, _) => "PerQuerier",
+            FilterId::Global(_) => "Global",
+            FilterId::TriggerQuota(_, _) => "TriggerQuota",
+            FilterId::SourceQuota(_, _) => "SourceQuota",
+        }
+    }
+
+    #[getter]
+    fn epoch_id(&self) -> u64 {
+        *self.inner.epoch_id()
+    }
+
+    #[getter]
+    fn uri(&self) -> Option<String> {
+        self.inner.uri().cloned()
+    }
+}
+
+impl From<FilterId<u64, String>> for PyFilterId {
+    fn from(inner: FilterId<u64, String>) -> Self {
+        PyFilterId { inner }
+    }
+}

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,7 +1,8 @@
 use pyo3::prelude::*;
 
+use pdslib::events::uri_set::UriSet;
 #[pymodule]
-fn pdslib(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.3.0")?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,44 +1,10 @@
 use pyo3::prelude::*;
 
-use pdslib::events::traits::EventUris;
-use pdslib::events::uri_set::UriSet;
+mod event_uris;
+mod uri_set;
 
-#[pyclass(name = "UriSet", unsendable)]
-#[derive(Clone)]
-pub struct PyUriSet {
-    pub inner: UriSet<String>,
-}
-
-#[pymethods]
-impl PyUriSet {
-    #[new]
-    fn new(uris: Vec<String>) -> Self {
-        PyUriSet { inner: uris.into() }
-    }
-}
-
-#[pyclass(name = "EventUris", unsendable)]
-pub struct PyEventUris {
-    pub inner: EventUris<String>,
-}
-
-#[pymethods]
-impl PyEventUris {
-    #[new]
-    fn new(
-        source_uri: String,
-        trigger_uris: PyUriSet,
-        querier_uris: PyUriSet,
-    ) -> Self {
-        PyEventUris {
-            inner: EventUris {
-                source_uri,
-                trigger_uris: trigger_uris.inner,
-                querier_uris: querier_uris.inner,
-            },
-        }
-    }
-}
+use event_uris::PyEventUris;
+use uri_set::PyUriSet;
 
 #[pymodule]
 fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,8 +1,10 @@
 use pyo3::prelude::*;
 
+use pdslib::events::traits::EventUris;
 use pdslib::events::uri_set::UriSet;
 
 #[pyclass(name = "UriSet", unsendable)]
+#[derive(Clone)]
 pub struct PyUriSet {
     pub inner: UriSet<String>,
 }
@@ -15,9 +17,33 @@ impl PyUriSet {
     }
 }
 
+#[pyclass(name = "EventUris", unsendable)]
+pub struct PyEventUris {
+    pub inner: EventUris<String>,
+}
+
+#[pymethods]
+impl PyEventUris {
+    #[new]
+    fn new(
+        source_uri: String,
+        trigger_uris: PyUriSet,
+        querier_uris: PyUriSet,
+    ) -> Self {
+        PyEventUris {
+            inner: EventUris {
+                source_uri,
+                trigger_uris: trigger_uris.inner,
+                querier_uris: querier_uris.inner,
+            },
+        }
+    }
+}
+
 #[pymodule]
 fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.3.0")?;
     m.add_class::<PyUriSet>()?;
+    m.add_class::<PyEventUris>()?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,7 +1,6 @@
 use pyo3::prelude::*;
 
 mod event_uris;
-mod filter_id;
 mod pds;
 mod ppa_event;
 mod ppa_histogram_config;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,9 +1,11 @@
 use pyo3::prelude::*;
 
 mod event_uris;
+mod report_request_uris;
 mod uri_set;
 
 use event_uris::PyEventUris;
+use report_request_uris::PyReportRequestUris;
 use uri_set::PyUriSet;
 
 #[pymodule]
@@ -11,5 +13,6 @@ fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.3.0")?;
     m.add_class::<PyUriSet>()?;
     m.add_class::<PyEventUris>()?;
+    m.add_class::<PyReportRequestUris>()?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,0 +1,7 @@
+use pyo3::prelude::*;
+
+#[pymodule]
+fn pdslib(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", "0.3.0")?;
+    Ok(())
+}

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -12,7 +12,6 @@ mod requested_buckets;
 mod uri_set;
 
 use event_uris::PyEventUris;
-use filter_id::PyFilterId;
 use pds::{PyPds, PyPdsReport};
 use ppa_event::PyPpaEvent;
 use ppa_histogram_config::{PyDirectPpaHistogramConfig, PyPpaHistogramConfig};
@@ -34,7 +33,6 @@ fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyRequestedBuckets>()?;
     m.add_class::<PyPpaRelevantEventSelector>()?;
     m.add_class::<PyPpaHistogramRequest>()?;
-    m.add_class::<PyFilterId>()?;
     m.add_class::<PyPds>()?;
     m.add_class::<PyPdsReport>()?;
     Ok(())

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2,12 +2,20 @@ use pyo3::prelude::*;
 
 mod event_uris;
 mod ppa_event;
+mod ppa_histogram_config;
+mod ppa_histogram_request;
+mod ppa_relevant_event_selector;
 mod report_request_uris;
+mod requested_buckets;
 mod uri_set;
 
 use event_uris::PyEventUris;
 use ppa_event::PyPpaEvent;
+use ppa_histogram_config::{PyDirectPpaHistogramConfig, PyPpaHistogramConfig};
+use ppa_histogram_request::PyPpaHistogramRequest;
+use ppa_relevant_event_selector::PyPpaRelevantEventSelector;
 use report_request_uris::PyReportRequestUris;
+use requested_buckets::PyRequestedBuckets;
 use uri_set::PyUriSet;
 
 #[pymodule]
@@ -17,5 +25,10 @@ fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyEventUris>()?;
     m.add_class::<PyReportRequestUris>()?;
     m.add_class::<PyPpaEvent>()?;
+    m.add_class::<PyPpaHistogramConfig>()?;
+    m.add_class::<PyDirectPpaHistogramConfig>()?;
+    m.add_class::<PyRequestedBuckets>()?;
+    m.add_class::<PyPpaRelevantEventSelector>()?;
+    m.add_class::<PyPpaHistogramRequest>()?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,10 +1,12 @@
 use pyo3::prelude::*;
 
 mod event_uris;
+mod ppa_event;
 mod report_request_uris;
 mod uri_set;
 
 use event_uris::PyEventUris;
+use ppa_event::PyPpaEvent;
 use report_request_uris::PyReportRequestUris;
 use uri_set::PyUriSet;
 
@@ -14,5 +16,6 @@ fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyUriSet>()?;
     m.add_class::<PyEventUris>()?;
     m.add_class::<PyReportRequestUris>()?;
+    m.add_class::<PyPpaEvent>()?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,8 +1,23 @@
 use pyo3::prelude::*;
 
 use pdslib::events::uri_set::UriSet;
+
+#[pyclass(name = "UriSet", unsendable)]
+pub struct PyUriSet {
+    pub inner: UriSet<String>,
+}
+
+#[pymethods]
+impl PyUriSet {
+    #[new]
+    fn new(uris: Vec<String>) -> Self {
+        PyUriSet { inner: uris.into() }
+    }
+}
+
 #[pymodule]
 fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.3.0")?;
+    m.add_class::<PyUriSet>()?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 
 mod event_uris;
+mod filter_id;
+mod pds;
 mod ppa_event;
 mod ppa_histogram_config;
 mod ppa_histogram_request;
@@ -10,6 +12,8 @@ mod requested_buckets;
 mod uri_set;
 
 use event_uris::PyEventUris;
+use filter_id::PyFilterId;
+use pds::{PyPds, PyPdsReport};
 use ppa_event::PyPpaEvent;
 use ppa_histogram_config::{PyDirectPpaHistogramConfig, PyPpaHistogramConfig};
 use ppa_histogram_request::PyPpaHistogramRequest;
@@ -30,5 +34,8 @@ fn pdslib_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyRequestedBuckets>()?;
     m.add_class::<PyPpaRelevantEventSelector>()?;
     m.add_class::<PyPpaHistogramRequest>()?;
+    m.add_class::<PyFilterId>()?;
+    m.add_class::<PyPds>()?;
+    m.add_class::<PyPdsReport>()?;
     Ok(())
 }

--- a/bindings/python/src/pds.rs
+++ b/bindings/python/src/pds.rs
@@ -1,0 +1,95 @@
+use pyo3::prelude::*;
+
+use pdslib::budget::traits::FilterStorage;
+use pdslib::pds::aliases::{PpaEventStorage, PpaFilterStorage, PpaPds};
+use pdslib::pds::quotas::StaticCapacities;
+
+use crate::filter_id::PyFilterId;
+use crate::ppa_event::PyPpaEvent;
+use crate::ppa_histogram_request::PyPpaHistogramRequest;
+
+#[pyclass(name = "Pds", unsendable)]
+pub struct PyPds {
+    inner: PpaPds,
+}
+
+#[pymethods]
+impl PyPds {
+    #[new]
+    fn new(
+        per_querier_budget: f64,
+        global_budget: f64,
+        trigger_quota: f64,
+        source_quota: f64,
+    ) -> PyResult<Self> {
+        let capacities = StaticCapacities::new(
+            per_querier_budget.into(),
+            global_budget.into(),
+            trigger_quota.into(),
+            source_quota.into(),
+        );
+
+        let filters = PpaFilterStorage::new(capacities).map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
+        })?;
+
+        let events = PpaEventStorage::new();
+
+        Ok(PyPds {
+            inner: PpaPds::new(filters, events),
+        })
+    }
+
+    fn register_event(&mut self, event: PyPpaEvent) -> PyResult<()> {
+        self.inner.register_event(event.inner).map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
+        })
+    }
+
+    fn compute_report(
+        &mut self,
+        request: &PyPpaHistogramRequest,
+    ) -> PyResult<PyPdsReport> {
+        let report =
+            self.inner.compute_report(&request.inner).map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
+            })?;
+
+        Ok(PyPdsReport {
+            filtered_bin_values: report
+                .filtered_report
+                .bin_values
+                .into_iter()
+                .collect(),
+            unfiltered_bin_values: report
+                .unfiltered_report
+                .bin_values
+                .into_iter()
+                .collect(),
+            oob_filters: report
+                .oob_filters
+                .into_iter()
+                .map(PyFilterId::from)
+                .collect(),
+        })
+    }
+}
+
+/// Report returned by Pds containing histogram bin values and budget information.
+#[pyclass(name = "PdsReport", unsendable)]
+pub struct PyPdsReport {
+    /// Histogram bin values after budget filtering is applied.
+    /// Epochs that exceeded their budget are excluded.
+    #[pyo3(get)]
+    pub filtered_bin_values: Vec<(u64, f64)>,
+
+    /// Histogram bin values before budget filtering.
+    /// Useful for debugging to see what the report would be without privacy constraints.
+    #[pyo3(get)]
+    pub unfiltered_bin_values: Vec<(u64, f64)>,
+
+    /// List of filters that were out of budget during the atomic check.
+    /// Empty if all filters had sufficient budget.
+    #[pyo3(get)]
+    pub oob_filters: Vec<PyFilterId>,
+}

--- a/bindings/python/src/pds.rs
+++ b/bindings/python/src/pds.rs
@@ -64,11 +64,8 @@ impl PyPds {
     }
 }
 
-/// Report returned by Pds containing histogram bin values.
 #[pyclass(name = "PdsReport", unsendable)]
 pub struct PyPdsReport {
-    /// Histogram bin values after budget filtering is applied.
-    /// Epochs that exceeded their budget are excluded.
     #[pyo3(get)]
     pub bin_values: Vec<(u64, f64)>,
 }

--- a/bindings/python/src/pds.rs
+++ b/bindings/python/src/pds.rs
@@ -20,7 +20,7 @@ impl PyPds {
         global_budget: f64,
         trigger_quota: f64,
         source_quota: f64,
-    ) -> PyResult<Self> {
+    ) -> anyhow::Result<Self> {
         let capacities = StaticCapacities::new(
             per_querier_budget.into(),
             global_budget.into(),
@@ -28,10 +28,7 @@ impl PyPds {
             source_quota.into(),
         );
 
-        let filters = PpaFilterStorage::new(capacities).map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
-        })?;
-
+        let filters = PpaFilterStorage::new(capacities)?;
         let events = PpaEventStorage::new();
 
         Ok(PyPds {
@@ -39,20 +36,16 @@ impl PyPds {
         })
     }
 
-    fn register_event(&mut self, event: PyPpaEvent) -> PyResult<()> {
-        self.inner.register_event(event.inner).map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
-        })
+    fn register_event(&mut self, event: PyPpaEvent) -> anyhow::Result<()> {
+        self.inner.register_event(event.inner)?;
+        Ok(())
     }
 
     fn compute_report(
         &mut self,
         request: &PyPpaHistogramRequest,
-    ) -> PyResult<PyPdsReport> {
-        let report =
-            self.inner.compute_report(&request.inner).map_err(|e| {
-                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
-            })?;
+    ) -> anyhow::Result<PyPdsReport> {
+        let report = self.inner.compute_report(&request.inner)?;
 
         Ok(PyPdsReport {
             bin_values: report

--- a/bindings/python/src/pds.rs
+++ b/bindings/python/src/pds.rs
@@ -69,7 +69,7 @@ impl PyPds {
             oob_filters: report
                 .oob_filters
                 .into_iter()
-                .map(PyFilterId::from)
+                .map(|inner| PyFilterId { inner })
                 .collect(),
         })
     }

--- a/bindings/python/src/pds.rs
+++ b/bindings/python/src/pds.rs
@@ -4,7 +4,6 @@ use pdslib::budget::traits::FilterStorage;
 use pdslib::pds::aliases::{PpaEventStorage, PpaFilterStorage, PpaPds};
 use pdslib::pds::quotas::StaticCapacities;
 
-use crate::filter_id::PyFilterId;
 use crate::ppa_event::PyPpaEvent;
 use crate::ppa_histogram_request::PyPpaHistogramRequest;
 
@@ -56,40 +55,20 @@ impl PyPds {
             })?;
 
         Ok(PyPdsReport {
-            filtered_bin_values: report
+            bin_values: report
                 .filtered_report
                 .bin_values
                 .into_iter()
-                .collect(),
-            unfiltered_bin_values: report
-                .unfiltered_report
-                .bin_values
-                .into_iter()
-                .collect(),
-            oob_filters: report
-                .oob_filters
-                .into_iter()
-                .map(|inner| PyFilterId { inner })
                 .collect(),
         })
     }
 }
 
-/// Report returned by Pds containing histogram bin values and budget information.
+/// Report returned by Pds containing histogram bin values.
 #[pyclass(name = "PdsReport", unsendable)]
 pub struct PyPdsReport {
     /// Histogram bin values after budget filtering is applied.
     /// Epochs that exceeded their budget are excluded.
     #[pyo3(get)]
-    pub filtered_bin_values: Vec<(u64, f64)>,
-
-    /// Histogram bin values before budget filtering.
-    /// Useful for debugging to see what the report would be without privacy constraints.
-    #[pyo3(get)]
-    pub unfiltered_bin_values: Vec<(u64, f64)>,
-
-    /// List of filters that were out of budget during the atomic check.
-    /// Empty if all filters had sufficient budget.
-    #[pyo3(get)]
-    pub oob_filters: Vec<PyFilterId>,
+    pub bin_values: Vec<(u64, f64)>,
 }

--- a/bindings/python/src/ppa_event.rs
+++ b/bindings/python/src/ppa_event.rs
@@ -1,0 +1,34 @@
+use pyo3::prelude::*;
+
+use pdslib::events::ppa_event::PpaEvent;
+
+use crate::event_uris::PyEventUris;
+
+#[pyclass(name = "PpaEvent", unsendable)]
+pub struct PyPpaEvent {
+    pub inner: PpaEvent<String>,
+}
+
+#[pymethods]
+impl PyPpaEvent {
+    #[new]
+    fn new(
+        id: u64,
+        timestamp: u64,
+        epoch_number: u64,
+        histogram_index: u64,
+        uris: PyEventUris,
+        filter_data: u64,
+    ) -> Self {
+        PyPpaEvent {
+            inner: PpaEvent {
+                id,
+                timestamp,
+                epoch_number,
+                histogram_index,
+                uris: uris.inner,
+                filter_data,
+            },
+        }
+    }
+}

--- a/bindings/python/src/ppa_event.rs
+++ b/bindings/python/src/ppa_event.rs
@@ -5,6 +5,7 @@ use pdslib::events::ppa_event::PpaEvent;
 use crate::event_uris::PyEventUris;
 
 #[pyclass(name = "PpaEvent", unsendable)]
+#[derive(Clone)]
 pub struct PyPpaEvent {
     pub inner: PpaEvent<String>,
 }

--- a/bindings/python/src/ppa_histogram_config.rs
+++ b/bindings/python/src/ppa_histogram_config.rs
@@ -1,0 +1,63 @@
+use pyo3::prelude::*;
+
+use pdslib::queries::ppa_histogram::{
+    DirectPpaHistogramConfig, PpaHistogramConfig,
+};
+
+#[pyclass(name = "PpaHistogramConfig", unsendable)]
+#[derive(Clone)]
+pub struct PyPpaHistogramConfig {
+    pub inner: PpaHistogramConfig,
+}
+
+#[pymethods]
+impl PyPpaHistogramConfig {
+    #[new]
+    fn new(
+        start_epoch: u64,
+        end_epoch: u64,
+        attributable_value: f64,
+        max_attributable_value: f64,
+        requested_epsilon: f64,
+        histogram_size: u64,
+    ) -> Self {
+        PyPpaHistogramConfig {
+            inner: PpaHistogramConfig {
+                start_epoch,
+                end_epoch,
+                attributable_value,
+                max_attributable_value,
+                requested_epsilon,
+                histogram_size,
+            },
+        }
+    }
+}
+
+#[pyclass(name = "DirectPpaHistogramConfig", unsendable)]
+#[derive(Clone)]
+pub struct PyDirectPpaHistogramConfig {
+    pub inner: DirectPpaHistogramConfig,
+}
+
+#[pymethods]
+impl PyDirectPpaHistogramConfig {
+    #[new]
+    fn new(
+        start_epoch: u64,
+        end_epoch: u64,
+        attributable_value: f64,
+        laplace_noise_scale: f64,
+        histogram_size: u64,
+    ) -> Self {
+        PyDirectPpaHistogramConfig {
+            inner: DirectPpaHistogramConfig {
+                start_epoch,
+                end_epoch,
+                attributable_value,
+                laplace_noise_scale,
+                histogram_size,
+            },
+        }
+    }
+}

--- a/bindings/python/src/ppa_histogram_request.rs
+++ b/bindings/python/src/ppa_histogram_request.rs
@@ -1,0 +1,46 @@
+use pyo3::prelude::*;
+
+use pdslib::queries::ppa_histogram::PpaHistogramRequest;
+
+use crate::ppa_histogram_config::{PyDirectPpaHistogramConfig, PyPpaHistogramConfig};
+use crate::ppa_relevant_event_selector::PyPpaRelevantEventSelector;
+
+#[pyclass(name = "PpaHistogramRequest", unsendable)]
+pub struct PyPpaHistogramRequest {
+    pub inner: PpaHistogramRequest<String>,
+}
+
+#[pymethods]
+impl PyPpaHistogramRequest {
+    #[staticmethod]
+    fn new_direct(
+        config: PyDirectPpaHistogramConfig,
+        relevant_event_selector: PyPpaRelevantEventSelector,
+    ) -> PyResult<Self> {
+        let request = PpaHistogramRequest::new_direct(
+            config.inner,
+            relevant_event_selector.into_inner(),
+        )
+        .map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())
+        })?;
+
+        Ok(PyPpaHistogramRequest { inner: request })
+    }
+
+    #[staticmethod]
+    fn new(
+        config: PyPpaHistogramConfig,
+        relevant_event_selector: PyPpaRelevantEventSelector,
+    ) -> PyResult<Self> {
+        let request = PpaHistogramRequest::new(
+            &config.inner,
+            relevant_event_selector.into_inner(),
+        )
+        .map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())
+        })?;
+
+        Ok(PyPpaHistogramRequest { inner: request })
+    }
+}

--- a/bindings/python/src/ppa_relevant_event_selector.rs
+++ b/bindings/python/src/ppa_relevant_event_selector.rs
@@ -8,16 +8,15 @@ use pdslib::queries::traits::ReportRequestUris;
 use crate::report_request_uris::PyReportRequestUris;
 use crate::requested_buckets::PyRequestedBuckets;
 
-/// Stores the parameters needed to build a PpaRelevantEventSelector.
-///
-/// The Rust struct has `is_matching_event: Box<dyn Fn(u64) -> bool>` for flexible
-/// event filtering. We simplify this to `filter_data: Option<u64>`:
-/// - `None` = match all events (equivalent to `|_| true`)
-/// - `Some(x)` = match events where filter_data == x
-///
-/// This covers the common use cases without GIL overhead from Python callables.
-/// A callable can be added later if complex matching is needed.
-///
+// Stores the parameters needed to build a PpaRelevantEventSelector.
+//
+// The Rust struct has `is_matching_event: Box<dyn Fn(u64) -> bool>` for flexible
+// event filtering. We simplify this to `filter_data: Option<u64>`:
+// - `None` = match all events (equivalent to `|_| true`)
+// - `Some(x)` = match events where filter_data == x
+//
+// This covers the common use cases without GIL overhead from Python callables.
+// A callable can be added later if complex matching is needed.
 #[pyclass(name = "PpaRelevantEventSelector", unsendable)]
 #[derive(Clone)]
 pub struct PyPpaRelevantEventSelector {

--- a/bindings/python/src/ppa_relevant_event_selector.rs
+++ b/bindings/python/src/ppa_relevant_event_selector.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 
-use pdslib::queries::ppa_histogram::{PpaRelevantEventSelector, RequestedBuckets};
+use pdslib::queries::ppa_histogram::{
+    PpaRelevantEventSelector, RequestedBuckets,
+};
 use pdslib::queries::traits::ReportRequestUris;
 
 use crate::report_request_uris::PyReportRequestUris;
@@ -14,7 +16,8 @@ use crate::requested_buckets::PyRequestedBuckets;
 /// - `Some(x)` = match events where filter_data == x
 ///
 /// This covers the common use cases without GIL overhead from Python callables.
-/// A callable could be added later if complex matching is needed.
+/// A callable can be added later if complex matching is needed.
+///
 #[pyclass(name = "PpaRelevantEventSelector", unsendable)]
 #[derive(Clone)]
 pub struct PyPpaRelevantEventSelector {
@@ -25,7 +28,8 @@ pub struct PyPpaRelevantEventSelector {
 
 impl PyPpaRelevantEventSelector {
     pub fn into_inner(self) -> PpaRelevantEventSelector<String> {
-        let is_matching_event: Box<dyn Fn(u64) -> bool> = match self.filter_data {
+        let is_matching_event: Box<dyn Fn(u64) -> bool> = match self.filter_data
+        {
             Some(fd) => {
                 Box::new(move |event_filter_data| event_filter_data == fd)
             }

--- a/bindings/python/src/ppa_relevant_event_selector.rs
+++ b/bindings/python/src/ppa_relevant_event_selector.rs
@@ -1,0 +1,58 @@
+use pyo3::prelude::*;
+
+use pdslib::queries::ppa_histogram::{PpaRelevantEventSelector, RequestedBuckets};
+use pdslib::queries::traits::ReportRequestUris;
+
+use crate::report_request_uris::PyReportRequestUris;
+use crate::requested_buckets::PyRequestedBuckets;
+
+/// Stores the parameters needed to build a PpaRelevantEventSelector.
+///
+/// The Rust struct has `is_matching_event: Box<dyn Fn(u64) -> bool>` for flexible
+/// event filtering. We simplify this to `filter_data: Option<u64>`:
+/// - `None` = match all events (equivalent to `|_| true`)
+/// - `Some(x)` = match events where filter_data == x
+///
+/// This covers the common use cases without GIL overhead from Python callables.
+/// A callable could be added later if complex matching is needed.
+#[pyclass(name = "PpaRelevantEventSelector", unsendable)]
+#[derive(Clone)]
+pub struct PyPpaRelevantEventSelector {
+    pub report_request_uris: ReportRequestUris<String>,
+    pub filter_data: Option<u64>,
+    pub requested_buckets: RequestedBuckets<u64>,
+}
+
+impl PyPpaRelevantEventSelector {
+    pub fn into_inner(self) -> PpaRelevantEventSelector<String> {
+        let is_matching_event: Box<dyn Fn(u64) -> bool> = match self.filter_data {
+            Some(fd) => {
+                Box::new(move |event_filter_data| event_filter_data == fd)
+            }
+            None => Box::new(|_| true),
+        };
+
+        PpaRelevantEventSelector {
+            report_request_uris: self.report_request_uris,
+            is_matching_event,
+            requested_buckets: self.requested_buckets,
+        }
+    }
+}
+
+#[pymethods]
+impl PyPpaRelevantEventSelector {
+    #[new]
+    #[pyo3(signature = (report_request_uris, filter_data, requested_buckets))]
+    fn new(
+        report_request_uris: PyReportRequestUris,
+        filter_data: Option<u64>,
+        requested_buckets: PyRequestedBuckets,
+    ) -> Self {
+        PyPpaRelevantEventSelector {
+            report_request_uris: report_request_uris.inner,
+            filter_data,
+            requested_buckets: requested_buckets.inner,
+        }
+    }
+}

--- a/bindings/python/src/report_request_uris.rs
+++ b/bindings/python/src/report_request_uris.rs
@@ -5,6 +5,7 @@ use pdslib::queries::traits::ReportRequestUris;
 use crate::uri_set::PyUriSet;
 
 #[pyclass(name = "ReportRequestUris", unsendable)]
+#[derive(Clone)]
 pub struct PyReportRequestUris {
     pub inner: ReportRequestUris<String>,
 }

--- a/bindings/python/src/report_request_uris.rs
+++ b/bindings/python/src/report_request_uris.rs
@@ -1,0 +1,28 @@
+use pyo3::prelude::*;
+
+use pdslib::queries::traits::ReportRequestUris;
+
+use crate::uri_set::PyUriSet;
+
+#[pyclass(name = "ReportRequestUris", unsendable)]
+pub struct PyReportRequestUris {
+    pub inner: ReportRequestUris<String>,
+}
+
+#[pymethods]
+impl PyReportRequestUris {
+    #[new]
+    fn new(
+        trigger_uri: String,
+        source_uris: PyUriSet,
+        querier_uris: PyUriSet,
+    ) -> Self {
+        PyReportRequestUris {
+            inner: ReportRequestUris {
+                trigger_uri,
+                source_uris: source_uris.inner,
+                querier_uris: querier_uris.inner,
+            },
+        }
+    }
+}

--- a/bindings/python/src/requested_buckets.rs
+++ b/bindings/python/src/requested_buckets.rs
@@ -1,0 +1,26 @@
+use pyo3::prelude::*;
+
+use pdslib::queries::ppa_histogram::RequestedBuckets;
+
+#[pyclass(name = "RequestedBuckets", unsendable)]
+#[derive(Clone)]
+pub struct PyRequestedBuckets {
+    pub inner: RequestedBuckets<u64>,
+}
+
+#[pymethods]
+impl PyRequestedBuckets {
+    #[staticmethod]
+    fn all_buckets() -> Self {
+        PyRequestedBuckets {
+            inner: RequestedBuckets::AllBuckets,
+        }
+    }
+
+    #[staticmethod]
+    fn specific_buckets(buckets: Vec<u64>) -> Self {
+        PyRequestedBuckets {
+            inner: buckets.into(),
+        }
+    }
+}

--- a/bindings/python/src/uri_set.rs
+++ b/bindings/python/src/uri_set.rs
@@ -1,0 +1,17 @@
+use pyo3::prelude::*;
+
+use pdslib::events::uri_set::UriSet;
+
+#[pyclass(name = "UriSet", unsendable)]
+#[derive(Clone)]
+pub struct PyUriSet {
+    pub inner: UriSet<String>,
+}
+
+#[pymethods]
+impl PyUriSet {
+    #[new]
+    fn new(uris: Vec<String>) -> Self {
+        PyUriSet { inner: uris.into() }
+    }
+}

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -26,3 +26,18 @@ def test_report_request_uris_create():
     querier_uris = pdslib_python.UriSet(["adtech.com"])
     report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
     assert report_uris is not None
+
+
+def test_ppa_event_create():
+    trigger_uris = pdslib_python.UriSet(["shoes.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
+    event = pdslib_python.PpaEvent(
+        id=1,
+        timestamp=0,
+        epoch_number=1,
+        histogram_index=1369,
+        uris=event_uris,
+        filter_data=1,
+    )
+    assert event is not None

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -1,208 +1,112 @@
+import pytest
+
 import pdslib_python
 
 
-def test_version():
-    assert pdslib_python.__version__ == "0.3.0"
-
-
-def test_module_exists():
-    assert pdslib_python is not None
-
-
-def test_uri_set_create():
-    uri_set = pdslib_python.UriSet(["shoes.com", "blog.com"])
-    assert uri_set is not None
-
-
-def test_event_uris_create():
+@pytest.fixture
+def event_uris():
     trigger_uris = pdslib_python.UriSet(["shoes.com"])
     querier_uris = pdslib_python.UriSet(["adtech.com"])
-    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
-    assert event_uris is not None
+    return pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
 
 
-def test_report_request_uris_create():
+@pytest.fixture
+def report_uris():
     source_uris = pdslib_python.UriSet(["blog.com"])
     querier_uris = pdslib_python.UriSet(["adtech.com"])
-    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
-    assert report_uris is not None
+    return pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
 
 
-def test_ppa_event_create():
-    trigger_uris = pdslib_python.UriSet(["shoes.com"])
-    querier_uris = pdslib_python.UriSet(["adtech.com"])
-    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
+@pytest.fixture
+def direct_config():
+    return pdslib_python.DirectPpaHistogramConfig(
+        start_epoch=1,
+        end_epoch=2,
+        attributable_value=32768.0,
+        laplace_noise_scale=131072.0,
+        histogram_size=2048,
+    )
+
+
+@pytest.fixture
+def pds():
+    return pdslib_python.Pds(1.0, 20.0, 1.5, 4.0)
+
+
+def test_compute_report(pds, event_uris, report_uris, direct_config):
     event = pdslib_python.PpaEvent(
         id=1,
         timestamp=0,
         epoch_number=1,
-        histogram_index=1369,
+        histogram_index=0x559,
         uris=event_uris,
         filter_data=1,
     )
-    assert event is not None
+    pds.register_event(event)
 
-
-def test_ppa_histogram_config_create():
-    config = pdslib_python.PpaHistogramConfig(
-        start_epoch=1,
-        end_epoch=2,
-        attributable_value=32768.0,
-        max_attributable_value=65536.0,
-        requested_epsilon=1.0,
-        histogram_size=2048,
-    )
-    assert config is not None
-
-
-def test_direct_ppa_histogram_config_create():
-    config = pdslib_python.DirectPpaHistogramConfig(
-        start_epoch=1,
-        end_epoch=2,
-        attributable_value=32768.0,
-        laplace_noise_scale=131072.0,
-        histogram_size=2048,
-    )
-    assert config is not None
-
-
-def test_requested_buckets_all():
-    buckets = pdslib_python.RequestedBuckets.all_buckets()
-    assert buckets is not None
-
-
-def test_requested_buckets_specific():
-    buckets = pdslib_python.RequestedBuckets.specific_buckets([0x559, 0x560])
-    assert buckets is not None
-
-
-def test_ppa_relevant_event_selector_create():
-    source_uris = pdslib_python.UriSet(["blog.com"])
-    querier_uris = pdslib_python.UriSet(["adtech.com"])
-    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
     selector = pdslib_python.PpaRelevantEventSelector(
         report_request_uris=report_uris,
         filter_data=1,
         requested_buckets=pdslib_python.RequestedBuckets.specific_buckets([0x559]),
     )
-    assert selector is not None
+    request = pdslib_python.PpaHistogramRequest.new_direct(direct_config, selector)
+
+    report = pds.compute_report(request)
+
+    assert len(report.bin_values) == 1
+    bucket, _ = report.bin_values[0]
+    assert bucket == 0x559
 
 
-def test_ppa_relevant_event_selector_match_all():
-    source_uris = pdslib_python.UriSet(["blog.com"])
-    querier_uris = pdslib_python.UriSet(["adtech.com"])
-    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
-    selector = pdslib_python.PpaRelevantEventSelector(
-        report_request_uris=report_uris,
-        filter_data=None,  # match all events
-        requested_buckets=pdslib_python.RequestedBuckets.all_buckets(),
+def test_filter_data_none_matches_all(pds, event_uris, report_uris, direct_config):
+    event = pdslib_python.PpaEvent(
+        id=1, timestamp=0, epoch_number=1, histogram_index=100,
+        uris=event_uris, filter_data=1,
     )
-    assert selector is not None
+    pds.register_event(event)
 
-
-def test_ppa_histogram_request_new_direct():
-    source_uris = pdslib_python.UriSet(["blog.com"])
-    querier_uris = pdslib_python.UriSet(["adtech.com"])
-    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
-    config = pdslib_python.DirectPpaHistogramConfig(
-        start_epoch=1,
-        end_epoch=2,
-        attributable_value=32768.0,
-        laplace_noise_scale=131072.0,
-        histogram_size=2048,
-    )
-    selector = pdslib_python.PpaRelevantEventSelector(
-        report_request_uris=report_uris,
-        filter_data=1,
-        requested_buckets=pdslib_python.RequestedBuckets.specific_buckets([0x559]),
-    )
-    request = pdslib_python.PpaHistogramRequest.new_direct(config, selector)
-    assert request is not None
-
-
-def test_ppa_histogram_request_new():
-    source_uris = pdslib_python.UriSet(["blog.com"])
-    querier_uris = pdslib_python.UriSet(["adtech.com"])
-    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
-    config = pdslib_python.PpaHistogramConfig(
-        start_epoch=1,
-        end_epoch=2,
-        attributable_value=32768.0,
-        max_attributable_value=65536.0,
-        requested_epsilon=1.0,
-        histogram_size=2048,
-    )
     selector = pdslib_python.PpaRelevantEventSelector(
         report_request_uris=report_uris,
         filter_data=None,
         requested_buckets=pdslib_python.RequestedBuckets.all_buckets(),
     )
-    request = pdslib_python.PpaHistogramRequest.new(config, selector)
-    assert request is not None
+    request = pdslib_python.PpaHistogramRequest.new_direct(direct_config, selector)
+    report = pds.compute_report(request)
+
+    assert len(report.bin_values) == 1
 
 
-def test_pds_create():
-    pds = pdslib_python.Pds(
-        per_querier_budget=1.0,
-        global_budget=20.0,
-        trigger_quota=1.5,
-        source_quota=4.0,
-    )
-    assert pds is not None
-
-
-def test_pds_register_event():
-    pds = pdslib_python.Pds(1.0, 20.0, 1.5, 4.0)
-    trigger_uris = pdslib_python.UriSet(["shoes.com"])
-    querier_uris = pdslib_python.UriSet(["adtech.com"])
-    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
+def test_filter_data_matches_same_value(pds, event_uris, report_uris, direct_config):
     event = pdslib_python.PpaEvent(
-        id=1,
-        timestamp=0,
-        epoch_number=1,
-        histogram_index=0x559,
-        uris=event_uris,
-        filter_data=1,
+        id=1, timestamp=0, epoch_number=1, histogram_index=100,
+        uris=event_uris, filter_data=1,
     )
     pds.register_event(event)
 
-
-def test_pds_compute_report():
-    pds = pdslib_python.Pds(1.0, 20.0, 1.5, 4.0)
-
-    # Register an event
-    trigger_uris = pdslib_python.UriSet(["shoes.com"])
-    querier_uris = pdslib_python.UriSet(["adtech.com"])
-    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
-    event = pdslib_python.PpaEvent(
-        id=1,
-        timestamp=0,
-        epoch_number=1,
-        histogram_index=0x559,
-        uris=event_uris,
-        filter_data=1,
-    )
-    pds.register_event(event)
-
-    # Create a report request
-    source_uris = pdslib_python.UriSet(["blog.com"])
-    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
-    config = pdslib_python.DirectPpaHistogramConfig(
-        start_epoch=1,
-        end_epoch=2,
-        attributable_value=32768.0,
-        laplace_noise_scale=131072.0,
-        histogram_size=2048,
-    )
     selector = pdslib_python.PpaRelevantEventSelector(
         report_request_uris=report_uris,
         filter_data=1,
-        requested_buckets=pdslib_python.RequestedBuckets.specific_buckets([0x559]),
+        requested_buckets=pdslib_python.RequestedBuckets.all_buckets(),
     )
-    request = pdslib_python.PpaHistogramRequest.new_direct(config, selector)
-
-    # Compute the report
+    request = pdslib_python.PpaHistogramRequest.new_direct(direct_config, selector)
     report = pds.compute_report(request)
-    assert report is not None
-    assert hasattr(report, "bin_values")
-    assert isinstance(report.bin_values, list)
+
+    assert len(report.bin_values) == 1
+
+
+def test_filter_data_excludes_different_value(pds, event_uris, report_uris, direct_config):
+    event = pdslib_python.PpaEvent(
+        id=1, timestamp=0, epoch_number=1, histogram_index=100,
+        uris=event_uris, filter_data=1,
+    )
+    pds.register_event(event)
+
+    selector = pdslib_python.PpaRelevantEventSelector(
+        report_request_uris=report_uris,
+        filter_data=999,
+        requested_buckets=pdslib_python.RequestedBuckets.all_buckets(),
+    )
+    request = pdslib_python.PpaHistogramRequest.new_direct(direct_config, selector)
+    report = pds.compute_report(request)
+
+    assert len(report.bin_values) == 0

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -139,3 +139,74 @@ def test_ppa_histogram_request_new():
     )
     request = pdslib_python.PpaHistogramRequest.new(config, selector)
     assert request is not None
+
+
+def test_pds_create():
+    pds = pdslib_python.Pds(
+        per_querier_budget=1.0,
+        global_budget=20.0,
+        trigger_quota=1.5,
+        source_quota=4.0,
+    )
+    assert pds is not None
+
+
+def test_pds_register_event():
+    pds = pdslib_python.Pds(1.0, 20.0, 1.5, 4.0)
+    trigger_uris = pdslib_python.UriSet(["shoes.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
+    event = pdslib_python.PpaEvent(
+        id=1,
+        timestamp=0,
+        epoch_number=1,
+        histogram_index=0x559,
+        uris=event_uris,
+        filter_data=1,
+    )
+    pds.register_event(event)
+
+
+def test_pds_compute_report():
+    pds = pdslib_python.Pds(1.0, 20.0, 1.5, 4.0)
+
+    # Register an event
+    trigger_uris = pdslib_python.UriSet(["shoes.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
+    event = pdslib_python.PpaEvent(
+        id=1,
+        timestamp=0,
+        epoch_number=1,
+        histogram_index=0x559,
+        uris=event_uris,
+        filter_data=1,
+    )
+    pds.register_event(event)
+
+    # Create a report request
+    source_uris = pdslib_python.UriSet(["blog.com"])
+    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
+    config = pdslib_python.DirectPpaHistogramConfig(
+        start_epoch=1,
+        end_epoch=2,
+        attributable_value=32768.0,
+        laplace_noise_scale=131072.0,
+        histogram_size=2048,
+    )
+    selector = pdslib_python.PpaRelevantEventSelector(
+        report_request_uris=report_uris,
+        filter_data=1,
+        requested_buckets=pdslib_python.RequestedBuckets.specific_buckets([0x559]),
+    )
+    request = pdslib_python.PpaHistogramRequest.new_direct(config, selector)
+
+    # Compute the report
+    report = pds.compute_report(request)
+    assert report is not None
+    assert hasattr(report, "filtered_bin_values")
+    assert hasattr(report, "unfiltered_bin_values")
+    assert hasattr(report, "oob_filters")
+    assert isinstance(report.filtered_bin_values, list)
+    assert isinstance(report.unfiltered_bin_values, list)
+    assert isinstance(report.oob_filters, list)

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -19,3 +19,10 @@ def test_event_uris_create():
     querier_uris = pdslib_python.UriSet(["adtech.com"])
     event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
     assert event_uris is not None
+
+
+def test_report_request_uris_create():
+    source_uris = pdslib_python.UriSet(["blog.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
+    assert report_uris is not None

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -1,0 +1,7 @@
+import pdslib
+
+def test_version():
+    assert pdslib.__version__ == "0.3.0"
+
+def test_module_exists():
+    assert pdslib is not None

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -1,7 +1,10 @@
-import pdslib
+import pdslib_python
+
 
 def test_version():
-    assert pdslib.__version__ == "0.3.0"
+    assert pdslib_python.__version__ == "0.3.0"
+
 
 def test_module_exists():
-    assert pdslib is not None
+    assert pdslib_python is not None
+

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -8,3 +8,7 @@ def test_version():
 def test_module_exists():
     assert pdslib_python is not None
 
+
+def test_uri_set_create():
+    uri_set = pdslib_python.UriSet(["shoes.com", "blog.com"])
+    assert uri_set is not None

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -204,9 +204,5 @@ def test_pds_compute_report():
     # Compute the report
     report = pds.compute_report(request)
     assert report is not None
-    assert hasattr(report, "filtered_bin_values")
-    assert hasattr(report, "unfiltered_bin_values")
-    assert hasattr(report, "oob_filters")
-    assert isinstance(report.filtered_bin_values, list)
-    assert isinstance(report.unfiltered_bin_values, list)
-    assert isinstance(report.oob_filters, list)
+    assert hasattr(report, "bin_values")
+    assert isinstance(report.bin_values, list)

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -12,3 +12,10 @@ def test_module_exists():
 def test_uri_set_create():
     uri_set = pdslib_python.UriSet(["shoes.com", "blog.com"])
     assert uri_set is not None
+
+
+def test_event_uris_create():
+    trigger_uris = pdslib_python.UriSet(["shoes.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    event_uris = pdslib_python.EventUris("blog.com", trigger_uris, querier_uris)
+    assert event_uris is not None

--- a/bindings/python/tests/test_pdslib.py
+++ b/bindings/python/tests/test_pdslib.py
@@ -41,3 +41,101 @@ def test_ppa_event_create():
         filter_data=1,
     )
     assert event is not None
+
+
+def test_ppa_histogram_config_create():
+    config = pdslib_python.PpaHistogramConfig(
+        start_epoch=1,
+        end_epoch=2,
+        attributable_value=32768.0,
+        max_attributable_value=65536.0,
+        requested_epsilon=1.0,
+        histogram_size=2048,
+    )
+    assert config is not None
+
+
+def test_direct_ppa_histogram_config_create():
+    config = pdslib_python.DirectPpaHistogramConfig(
+        start_epoch=1,
+        end_epoch=2,
+        attributable_value=32768.0,
+        laplace_noise_scale=131072.0,
+        histogram_size=2048,
+    )
+    assert config is not None
+
+
+def test_requested_buckets_all():
+    buckets = pdslib_python.RequestedBuckets.all_buckets()
+    assert buckets is not None
+
+
+def test_requested_buckets_specific():
+    buckets = pdslib_python.RequestedBuckets.specific_buckets([0x559, 0x560])
+    assert buckets is not None
+
+
+def test_ppa_relevant_event_selector_create():
+    source_uris = pdslib_python.UriSet(["blog.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
+    selector = pdslib_python.PpaRelevantEventSelector(
+        report_request_uris=report_uris,
+        filter_data=1,
+        requested_buckets=pdslib_python.RequestedBuckets.specific_buckets([0x559]),
+    )
+    assert selector is not None
+
+
+def test_ppa_relevant_event_selector_match_all():
+    source_uris = pdslib_python.UriSet(["blog.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
+    selector = pdslib_python.PpaRelevantEventSelector(
+        report_request_uris=report_uris,
+        filter_data=None,  # match all events
+        requested_buckets=pdslib_python.RequestedBuckets.all_buckets(),
+    )
+    assert selector is not None
+
+
+def test_ppa_histogram_request_new_direct():
+    source_uris = pdslib_python.UriSet(["blog.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
+    config = pdslib_python.DirectPpaHistogramConfig(
+        start_epoch=1,
+        end_epoch=2,
+        attributable_value=32768.0,
+        laplace_noise_scale=131072.0,
+        histogram_size=2048,
+    )
+    selector = pdslib_python.PpaRelevantEventSelector(
+        report_request_uris=report_uris,
+        filter_data=1,
+        requested_buckets=pdslib_python.RequestedBuckets.specific_buckets([0x559]),
+    )
+    request = pdslib_python.PpaHistogramRequest.new_direct(config, selector)
+    assert request is not None
+
+
+def test_ppa_histogram_request_new():
+    source_uris = pdslib_python.UriSet(["blog.com"])
+    querier_uris = pdslib_python.UriSet(["adtech.com"])
+    report_uris = pdslib_python.ReportRequestUris("shoes.com", source_uris, querier_uris)
+    config = pdslib_python.PpaHistogramConfig(
+        start_epoch=1,
+        end_epoch=2,
+        attributable_value=32768.0,
+        max_attributable_value=65536.0,
+        requested_epsilon=1.0,
+        histogram_size=2048,
+    )
+    selector = pdslib_python.PpaRelevantEventSelector(
+        report_request_uris=report_uris,
+        filter_data=None,
+        requested_buckets=pdslib_python.RequestedBuckets.all_buckets(),
+    )
+    request = pdslib_python.PpaHistogramRequest.new(config, selector)
+    assert request is not None

--- a/justfile
+++ b/justfile
@@ -15,3 +15,6 @@ format:
     cargo +nightly fmt
     cargo clippy --fix --allow-dirty
     cargo clippy --tests  -- -D warnings
+
+python-test:
+    cd bindings/python && maturin develop && .venv/bin/pytest tests/


### PR DESCRIPTION
Add Python bindings for `compute_report()`. (closes https://github.com/columbia/pdslib/issues/100). Uses [PyO3](https://github.com/PyO3/pyo3).

Dependencies:
- [`UriSet`](https://github.com/columbia/pdslib/blob/main/src/events/uri_set.rs#L12), used by [`EventUris`](https://github.com/columbia/pdslib/blob/main/src/events/traits.rs#L26), [`ReportRequestUris`](https://github.com/columbia/pdslib/blob/main/src/queries/traits.rs#L17)
- [`EventUris`](https://github.com/columbia/pdslib/blob/main/src/events/traits.rs#L21), used by [`PpaEvent`](https://github.com/columbia/pdslib/blob/main/src/events/ppa_event.rs#L23)
- [`PpaEvent`](https://github.com/columbia/pdslib/blob/main/src/events/ppa_event.rs#L11), used by [`Pds.register_event()`](https://github.com/columbia/pdslib/blob/main/src/pds/private_data_service.rs#L76) (in order to register events to report on)
- [`ReportRequestUris`](https://github.com/columbia/pdslib/blob/main/src/queries/traits.rs#L12), used by [`PpaHistogramRequest`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L146)
- [`PpaHistogramConfig`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L70), used by [`PpaHistogramRequest.new()`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L157)
- [`DirectPpaHistogramConfig`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L89), used by [`PpaHistogramRequest.new_direct()`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L198)
- [`RequestedBuckets`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L45), used by [`PpaRelevantEventSelector`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L33)
- [`PpaHistogramRequest`](https://github.com/columbia/pdslib/blob/main/src/queries/ppa_histogram.rs#L139), used by [`Pds.compute_report()`](https://github.com/columbia/pdslib/blob/main/src/pds/private_data_service.rs#L83)
- [`Pds`](https://github.com/columbia/pdslib/blob/main/src/pds/private_data_service.rs#L20), implements [`register_event()`](https://github.com/columbia/pdslib/blob/main/src/pds/private_data_service.rs#L76) and [`compute_report()`](https://github.com/columbia/pdslib/blob/main/src/pds/private_data_service.rs#L83)

Note: These all link to line numbers. GitHub seems to be having an issue where they're stripped if you just click on the link. However, if you cmd+click or shift+click to open in a new tab, they work correctly.

TODO:
- [x] Library scaffolding ([dc5e6b7](https://github.com/columbia/pdslib/pull/101/commits/dc5e6b74d3a2f446e868acc3fb59864ab1ec9cb8))
- [x] `UriSet` ([a6a17f7](https://github.com/columbia/pdslib/pull/101/commits/a6a17f739b74288d96438d600bed3c7ef7970ac3))
- [x] `EventUris` ([5e6cca3](https://github.com/columbia/pdslib/pull/101/commits/5e6cca300ba71d76a4f76e4f0ad00a38bf6d2390))
- [x] `ReportRequestUris` ([080ca04](https://github.com/columbia/pdslib/pull/101/commits/080ca04084e8d7cdbd60aa37733a65a381d1de20))
- [x] `PpaEvent` (https://github.com/columbia/pdslib/pull/101/changes/b32cc7fca17b37db69fafba8ad91fb4e4c70f3ad)
- [x] `PpaHistogramConfig` ([f56e645](https://github.com/columbia/pdslib/pull/101/commits/f56e6453accaaf61f7fc79b631c0996225b91d13))
- [x] `DirectPpaHistogramConfig` ([f56e645](https://github.com/columbia/pdslib/pull/101/commits/f56e6453accaaf61f7fc79b631c0996225b91d13))
- [x] `RequestedBuckets` ([52bcd44](https://github.com/columbia/pdslib/pull/101/commits/52bcd44373d46147f892a4881c81e76fb137e86e))
- [x] `PpaRelevantEventSelector` ([8534d72](https://github.com/columbia/pdslib/pull/101/commits/8534d72a891468c74934b545af9d457318df8e6a))
- [x] `PpaHistogramRequest` ([72413a0](https://github.com/columbia/pdslib/pull/101/commits/72413a0177f76f59445cbd3203919c5cab4fdadd))
- [x] `Pds` (register_event, compute_report) ([2457d7d](https://github.com/columbia/pdslib/pull/101/commits/2457d7dd11fe5eccb9220bd82ae2e87c5fad038f))
- [x] Add documentation ([a360fc3](https://github.com/columbia/pdslib/pull/101/commits/a360fc3aec8f5bbec88ca122bd4255f042740dc1))
- [x] Run tests on CI ([d1600c2](https://github.com/columbia/pdslib/pull/101/commits/d1600c2670f56009a930132a0c7adccd1dd908ce))

## Questions

- `PpaRelevantEventSelector.filter_data` is simplified from the Rust API. The Python bindings take
  `int | None`, where `int` matches events with that exact `filter_data` value, and `None` matches all events. A Python callable would require acquiring the GIL for every event checked, and I wasn't sure if that kind of latency is OK. Do we want to support the Rust API closure in a future PR, or is the simplified version sufficient for these bindings? 
- Experimental features from the Rust library (`unfiltered_bin_values`, `oob_filters`) are not currently exposed in
  these bindings. Do we want to add these in a future PR?
- This PR exposes both `PpaHistogramConfig` and `DirectPpaHistogramConfig` for parity with the Rust API. Do we want to keep both of these in the bindings, or did we want to simplify?