### PR TITLE
Add unfiltered results with experimental flag

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,5 +9,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-pdslib = { path = "../.." }
+pdslib = { path = "../..", features = ["experimental"] }
 pyo3 = { version = "0.27", features = ["extension-module", "anyhow"] }
+
+[features]
+default = []
+experimental = ["pdslib/experimental"]

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -74,7 +74,7 @@ for bucket, value in report.bin_values:
 
 - `PpaRelevantEventSelector.filter_data` is simplified from the Rust API. The Python bindings take
   `int | None`, where `int` matches events with that exact `filter_data` value, and `None` matches all events.
-- Experimental features from the Rust library (`unfiltered_bin_values`, `oob_filters`) are not currently exposed in
+- Experimental feature from the Rust library (`oob_filters`) is not currently exposed in
   these bindings.
 
 ## Development

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 dev = ["pytest>=9.0"]
+experimental = []
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "experimental"]

--- a/bindings/python/src/pds.rs
+++ b/bindings/python/src/pds.rs
@@ -53,6 +53,12 @@ impl PyPds {
                 .bin_values
                 .into_iter()
                 .collect(),
+            #[cfg(feature = "experimental")]
+            unfiltered_bin_values: report
+                .unfiltered_report
+                .bin_values
+                .into_iter()
+                .collect(),
         })
     }
 }
@@ -61,4 +67,8 @@ impl PyPds {
 pub struct PyPdsReport {
     #[pyo3(get)]
     pub bin_values: Vec<(u64, f64)>,
+
+    #[cfg(feature = "experimental")]
+    #[pyo3(get)]
+    pub unfiltered_bin_values: Vec<(u64, f64)>,
 }


### PR DESCRIPTION
Expose unfiltered_bin_values in python bindings via the experimental feature flag